### PR TITLE
Rewrite operation page logic to use operation ID's

### DIFF
--- a/src/components/operations/CommandPopup.vue
+++ b/src/components/operations/CommandPopup.vue
@@ -1,11 +1,11 @@
 <script setup>
 import { inject, ref, computed } from "vue";
 
-import { useOperationStore } from '@/stores/operationStore';
+import { useOperationStore } from "@/stores/operationStore";
 import { b64DecodeUnicode } from "@/utils/utils";
 
 const props = defineProps({
-    link: Object
+  link: Object,
 });
 
 const $api = inject("$api");
@@ -15,20 +15,26 @@ const operationStore = useOperationStore();
 let editableCommand = ref();
 
 const command = computed(() => {
-    return b64DecodeUnicode(props.link.command);
+  if (props.link.command === props.link.plaintext_command) return "";
+  return props.link.command;
 });
 const plaintextCommand = computed(() => {
-    return b64DecodeUnicode(props.link.plaintext_command);
+  return props.link.plaintext_command;
 });
 const isCommandObfuscated = computed(() => {
-    return command.value !== plaintextCommand.value;
+  return command.value !== "";
 });
 
 function isLinkEditable(currentLink) {
-    if (!currentLink) return false;
-    editableCommand.value = props.link.command;
-    // Link can only be editable if operation is running, and if link is paused, queued, or completed
-    return operationStore.isOperationRunning() && ((currentLink.status === -1) && !(currentLink.finish.length > 0 || currentLink.output === 'True'));
+  if (!currentLink) return false;
+  if (!currentLink.finish) return false;
+  editableCommand.value = props.link.command;
+  // Link can only be editable if operation is running, and if link is paused, queued, or completed
+  return (
+    operationStore.isOperationRunning() &&
+    currentLink.status === -1 &&
+    !(currentLink.finish.length > 0 || currentLink.output === "True")
+  );
 }
 </script>
 
@@ -42,7 +48,7 @@ section(v-if="isLinkEditable(props.link)")
         pre.m-0.pt-2.pb-2 {{ command }}
         label.label.mt-2 Plaintext
         pre.m-0.pt-2.pb-2 {{ plaintextCommand }}
-    pre.m-0.pt-2.pb-2(v-else) {{ command }}
+    pre.m-0.pt-2.pb-2(v-else) {{ plaintextCommand }}
     
 .buttons
     button.button.is-primary(v-if="isLinkEditable(props.link)" @click="operationStore.updateLink($api, -3, editableCommand)") Approve

--- a/src/components/operations/CreateModal.vue
+++ b/src/components/operations/CreateModal.vue
@@ -20,6 +20,12 @@ const agentStore = useAgentStore();
 const sourceStore = useSourceStore();
 const { sources } = storeToRefs(sourceStore);
 
+const props = defineProps({
+    selectInterval: {
+        type: Function,
+    },
+});
+
 let operationName = ref("");
 let selectedAdversary = ref("");
 let selectedSource = ref("")
@@ -87,7 +93,12 @@ async function createOperation() {
         adversary: {adversary_id: JSON.parse(JSON.stringify(selectedAdversary.value.adversary_id))},
         group: selectedGroup.value,
     };
-    await operationStore.createOperation($api, newOperation);
+    try {
+        await operationStore.createOperation($api, newOperation);
+        props.selectInterval();
+    } catch(error) {
+        console.error("Error creating operation", error);
+    }
     modals.value.operations.showCreate = false
 }
 

--- a/src/components/operations/DeleteModal.vue
+++ b/src/components/operations/DeleteModal.vue
@@ -12,7 +12,7 @@ const { modals } = storeToRefs(coreDisplayStore);
 const operationStore = useOperationStore();
 
 async function deleteOperation() {
-    await operationStore.deleteOperation($api, operationStore.selectedOperation.id);
+    await operationStore.deleteOperation($api, operationStore.selectedOperationID);
     modals.value.operations.showDelete = false;
 }
 </script>
@@ -23,8 +23,8 @@ async function deleteOperation() {
     .modal-card
         header.modal-card-head 
             p.modal-card-title Delete Operation?
-        .modal-card-body 
-            p Are you sure you want to delete the operation "{{ operationStore.selectedOperation.name }}"? This cannot be undone.
+        .modal-card-body(v-if="operationStore.currentOperation")
+            p Are you sure you want to delete the operation "{{ operationStore.currentOperation.name }}"? This cannot be undone.
         footer.modal-card-foot.has-text-right
             button.button(@click="modals.operations.showDelete = false") Cancel 
             button.button.is-danger(@click="deleteOperation()") 

--- a/src/components/operations/DetailsModal.vue
+++ b/src/components/operations/DetailsModal.vue
@@ -14,39 +14,39 @@ const operationStore = useOperationStore();
     .modal-card
         header.modal-card-head 
             p.modal-card-title Operation Details
-        .modal-card-body(v-if="operationStore.selectedOperation.id")
+        .modal-card-body(v-if="operationStore.selectedOperationID")
             table.table.is-fullwidth.is-striped
                 tbody
                     tr
                         th Name
-                        td {{`${operationStore.selectedOperation.name}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].name}`}}
                     tr
                         th Adversary
-                        td {{`${operationStore.selectedOperation.adversary.name}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].adversary.name}`}}
                     tr
                         th Fact Source
-                        td {{`${operationStore.selectedOperation.source.name}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].source.name}`}}
                     tr
                         th Group
-                        td {{operationStore.selectedOperation.autonomous ? "all" : "red"}}
+                        td {{operationStore.operations[operationStore.selectedOperationID].autonomous ? "all" : "red"}}
                     tr
                         th Planner
-                        td {{`${operationStore.selectedOperation.planner.name}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].planner.name}`}}
                     tr
                         th Obfuscator
-                        td {{`${operationStore.selectedOperation.obfuscator}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].obfuscator}`}}
                     tr
                         th Autonomous
-                        td {{operationStore.selectedOperation.autonomous ? "autonomous" : "manual"}}
+                        td {{operationStore.operations[operationStore.selectedOperationID].autonomous ? "autonomous" : "manual"}}
                     tr
                         th Parser
-                        td {{`${operationStore.selectedOperation.use_learning_parsers}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].use_learning_parsers}`}}
                     tr
                         th Auto Close
-                        td {{`${operationStore.selectedOperation.auto_close}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].auto_close}`}}
                     tr
                         th Jitter
-                        td {{`${operationStore.selectedOperation.jitter}`}}
+                        td {{`${operationStore.operations[operationStore.selectedOperationID].jitter}`}}
         footer.modal-card-foot.is-justify-content-right
             button.button(@click="modals.operations.showDetails = false") Close 
             

--- a/src/components/operations/DownloadModal.vue
+++ b/src/components/operations/DownloadModal.vue
@@ -2,7 +2,7 @@
 import { inject, ref } from "vue";
 import { storeToRefs } from "pinia";
 import { useCoreDisplayStore } from "../../stores/coreDisplayStore";
-import { useOperationStore } from '../../stores/operationStore';
+import { useOperationStore } from "../../stores/operationStore";
 const $api = inject("$api");
 const coreDisplayStore = useCoreDisplayStore();
 const { modals } = storeToRefs(coreDisplayStore);
@@ -11,10 +11,14 @@ let reportType = ref(1);
 let isAgentOutput = ref(false);
 
 async function downloadOperation() {
-    await operationStore.downloadOperationInfo($api, reportType.value, operationStore.selectedOperation.id, isAgentOutput.value);
-    modals.value.operations.showDownload = false;
+  await operationStore.downloadOperationInfo(
+    $api,
+    reportType.value,
+    operationStore.selectedOperationID,
+    isAgentOutput.value
+  );
+  modals.value.operations.showDownload = false;
 }
-
 </script>
 
 <template lang="pug">
@@ -46,6 +50,6 @@ async function downloadOperation() {
 
 <style scoped>
 .modal-card-foot {
-    display: block;
+  display: block;
 }
 </style>

--- a/src/components/operations/ManualCommand.vue
+++ b/src/components/operations/ManualCommand.vue
@@ -13,28 +13,28 @@ const { modals } = storeToRefs(coreDisplayStore);
 const $api = inject("$api");
 
 const manualCommand = reactive({
-    agent: operationStore.selectedOperation.host_group[0],
-    executor: {
-        name: operationStore.selectedOperation.host_group[0].executors[0],
-        command: "",
-        platform: ""    
-    },
-    paw: "",
+  agent: operationStore.currentOperation.host_group[0],
+  executor: {
+    name: operationStore.currentOperation.host_group[0].executors[0],
+    command: "",
+    platform: "",
+  },
+  paw: "",
 });
 
 function addManualCommand() {
-    if (manualCommand.executor.command.length <= 0) {
-        //TODO tell user to enter manual command
-        return;
-    }
-    manualCommand.paw = manualCommand.agent.paw;
-    manualCommand.executor.platform = manualCommand.agent.platform;
-    if (operationStore.selectedOperation.state === "paused") {
-        // TODO tell user operation is paused
-        modals.value.operations.showAddManualCommand = false;
-    }
-    operationStore.addManualCommand($api, manualCommand);
+  if (manualCommand.executor.command.length <= 0) {
+    //TODO tell user to enter manual command
+    return;
+  }
+  manualCommand.paw = manualCommand.agent.paw;
+  manualCommand.executor.platform = manualCommand.agent.platform;
+  if (operationStore.currentOperation.state === "paused") {
+    // TODO tell user operation is paused
     modals.value.operations.showAddManualCommand = false;
+  }
+  operationStore.addManualCommand($api, manualCommand);
+  modals.value.operations.showAddManualCommand = false;
 }
 </script>
 
@@ -46,7 +46,7 @@ tr(id="manual-input-command")
             .select
                 select(v-model="manualCommand.agent")
                     option(disabled default value="") Select an agent
-                    option(v-for="(agent, idx) in operationStore.selectedOperation.host_group" :key="agent.paw" :value="agent") {{ `${agent.display_name} - ${agent.paw}` }}
+                    option(v-for="(agent, idx) in operationStore.currentOperation.host_group" :key="agent.paw" :value="agent") {{ `${agent.display_name} - ${agent.paw}` }}
     td
         .control
             .select 

--- a/src/components/operations/OutputPopup.vue
+++ b/src/components/operations/OutputPopup.vue
@@ -26,7 +26,7 @@ onMounted(() => {
 async function getLinkOutput() {
     if (props.link.output !== "True") return;
     try {
-        const response = await $api.get(`/api/v2/operations/${operationStore.selectedOperation.id}/links/${props.link.id}/result`);
+        const response = await $api.get(`/api/v2/operations/${operationStore.selectedOperationID}/links/${props.link.id}/result`);
         const result = JSON.parse(b64DecodeUnicode(response.data.result));
         stdout.value = result.stdout;
         stderr.value = result.stderr;

--- a/src/stores/operationStore.js
+++ b/src/stores/operationStore.js
@@ -2,177 +2,217 @@ import { defineStore } from "pinia";
 import { b64DecodeUnicode } from "../utils/utils";
 
 export const useOperationStore = defineStore("operationStore", {
-    state: () => {
-        return {
-            operations: [],
-            selectedOperation: {},
-            selectedLink: {},
-            facts: {}
-        };
+  state: () => {
+    return {
+      operations: {},
+      selectedOperationID: "",
+      selectedLink: {},
+      facts: {},
+    };
+  },
+  getters: {
+    currentOperation(state) {
+      return state.operations[state.selectedOperationID];
     },
-
-    actions: {
-        async getOperations($api) {
-            try {
-                const response = await $api.get("/api/v2/operations");
-                // TODO: Sort operations
-                this.operations = response.data;
-            } catch(error) {
-                console.error("Error fetching operations", error);
-            }
-        },
-        async createOperation($api, operation) {
-            try{
-                const response = await $api.post("/api/v2/operations", operation);
-                this.operations.push(response.data);
-                this.selectedOperation = response.data;
-            } catch(error) {
-                console.error("Error creating operation", error);
-            }
-        },
-        async deleteOperation($api, operationID) {
-            try{
-                await $api.delete(`/api/v2/operations/${operationID}`);
-                this.selectedOperation = "";
-                this.operations = this.operations.filter(el => el.id !== operationID);
-            } catch(error){
-                console.error("Error deleting operation", error);
-            }
-        },
-        async updateOperationChain($api) {
-            try {
-                const response = await $api.get(`/api/v2/operations/${this.selectedOperation.id}`);
-                // Make sure we are updating the correct operation just in case
-                if(this.selectedOperation.id != response.data.id){
-                    return;
-                }
-                Object.assign(this.selectedOperation, response.data);
-            } catch(error) {
-                console.error("Error updating operation chain", error);
-            }
-
-        },
-        async updateOperation($api, field, updateValue) {
-            this.selectedOperation[field] = updateValue;
-            try {
-                const response = await $api.patch(`/api/v2/operations/${this.selectedOperation.id}`, this.selectedOperation);
-                return response.data;
-            } catch(error) {
-                console.error("Error updating operation", error);
-            }
-        },
-        async rerunOperation($api){
-            let { id, start, state, chain, host_group, ...newOp } = this.selectedOperation;
-            let dateMatches = newOp.name.match(/[(]\d{1,2}\/\d{1,2}\/\d{2,4}, \d{1,2}:\d{2}:\d{2} [A|P]M[)]$/g);
-            let stringToReplace = (dateMatches && dateMatches.length) ? dateMatches[dateMatches.length - 1] : '';
-            let date = `(${new Date().toLocaleString()})`;
-            newOp.name = stringToReplace ? (newOp.name.replace(stringToReplace, date)) : (`${newOp.name} ${date}`);
-            try {
-                const response = await $api.post('/api/v2/operations', newOp);
-                this.operations.push(response.data);
-                this.selectedOperation = response.data;
-            } catch (error) {
-                console.error("Error rerunning operation", error);
-            }
-        },
-        isOperationRunning() {
-            if (!this.selectedOperation) return false;
-            return !(this.selectedOperation.state === 'finished' || this.selectedOperation.state === 'cleanup' || this.selectedOperation.state === 'out_of_time');
-        },
-        async updateLink($api, status, command = null) {
-            const updatedLink = {
-                ...this.selectedLink,
-                command: b64DecodeUnicode(this.selectedLink.command)
-            };
-            if (command) updatedLink.command = command;
-            updatedLink.status = status;
-            try {
-                const response = await $api.patch(`/api/v2/operations/${this.selectedOperation.id}/links/${this.selectedLink.id}`, updatedLink);
-                await this.updateOperationChain($api);
-                return response.data;
-            } catch (error) {
-                console.error("Error updating link state", error);
-            }
-        },
-        async addManualCommand($api, manualCommand) {
-            try {
-                const response = await $api.post(`/api/v2/operations/${this.selectedOperation.id}/potential-links`, manualCommand);
-                await this.updateOperationChain($api);
-                return response.data;
-            } catch (error) {
-                console.error("Error adding manual command", error);
-            }
-        },
-        async addPotentialLinks($api, potentialLink) {
-            try {
-                for (let link of potentialLink) {
-                    await $api.post(`/api/v2/operations/${this.selectedOperation.id}/potential-links`, link);
-                }
-                await this.updateOperationChain($api);
-            } catch (error) {
-                console.error("Error adding potential links", error);
-            }
-        },
-        async getFacts($api) {
-            if (!this.selectedOperation) return;
-            try {
-                const response = await $api.get(`/api/v2/facts/${this.selectedOperation.id}`);
-                this.facts = response.data.found;
-            } catch (error) {
-                console.error("Error getting facts");
-            }
-        },
-        async downloadOperationInfo($api, format, operationID, isAgentOutput) {
-            switch (format){
-                case 0:
-                    format = "report";
-                    break;
-                case 1:
-                    format = "event-logs";
-                    break;
-                case 2:
-                    format = "csv";
-                    break;
-                default:
-                    format = "report";
-                    break;
-            }
-            if(format !== "csv"){            
-                try{
-                    const response = await $api.post(`/api/v2/operations/${operationID}/${format}`, {enable_agent_output: isAgentOutput});
-                    const data = JSON.stringify(response.data);
-                    const blob = new Blob([data], {type: 'text/plain'})
-                    this.createDownloadReport(blob, 'json', format)
-                } catch(error) {
-                    console.error("Error downloading operation", error);
-                }
-            }else{
-                let csv = [ 'Time Ran,Ability Name,Agent,Host,pid,Link Command,Link Output' ]
-                this.selectedOperation.chain.forEach((link) => {
-                    const rowItems = [];
-                    rowItems.push(link.decide);
-                    rowItems.push(link.ability.name);
-                    rowItems.push(link.paw);
-                    rowItems.push(link.host);
-                    rowItems.push(link.pid);
-                    rowItems.push(b64DecodeUnicode(link.command));
-                    rowItems.push(b64DecodeUnicode(link.plaintext_command));
-                    csv.push(rowItems.join(','));
-                });
-                const blob = new Blob([csv.join('\n')], {type: 'text/csv'});
-                this.createDownloadReport(blob, 'csv', format); 
-            }
-
-        },
-        createDownloadReport(blob, fileName, format) {
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.style.display = 'none';
-            a.href = url;
-            a.download = `${this.selectedOperation.name}_${format}.${fileName}`;
-            document.body.appendChild(a);
-            a.click();
-            window.URL.revokeObjectURL(url);
+  },
+  actions: {
+    async getOperations($api) {
+      try {
+        const response = await $api.get("/api/v2/operations");
+        // TODO: Sort operations
+        for (const operation of response.data) {
+          this.operations[operation.id] = operation;
         }
+      } catch (error) {
+        console.error("Error fetching operations", error);
+      }
     },
+    async createOperation($api, operation) {
+      try {
+        const response = await $api.post("/api/v2/operations", operation);
+        this.operations[response.data.id] = response.data;
+        this.selectedOperationID = response.data.id;
+      } catch (error) {
+        console.error("Error creating operation", error);
+      }
+    },
+    async deleteOperation($api, operationID) {
+      try {
+        await $api.delete(`/api/v2/operations/${operationID}`);
+        delete this.operations[operationID];
+        this.selectedOperationID = "";
+        this.getOperations($api);
+      } catch (error) {
+        console.error("Error deleting operation", error);
+      }
+    },
+    async updateOperationChain($api) {
+      try {
+        const response = await $api.get(
+          `/api/v2/operations/${this.selectedOperationID}`
+        );
+        if (this.selectedOperationID != response.data.id) {
+          return;
+        }
+        operations[this.selectedOperationID] = response.data;
+      } catch (error) {
+        console.error("Error updating operation chain", error);
+      }
+    },
+    async updateOperation($api, field, updateValue) {
+      const newOperation = { ...this.operations[this.selectedOperationID] };
+      newOperation[field] = updateValue;
+      try {
+        await $api.patch(
+          `/api/v2/operations/${this.selectedOperationID}`,
+          newOperation
+        );
+        this.getOperations($api);
+      } catch (error) {
+        console.error("Error updating operation", error);
+      }
+    },
+    async rerunOperation($api) {
+      let { id, start, state, chain, host_group, ...newOp } =
+        this.operations[this.selectedOperationID];
+      let dateMatches = newOp.name.match(
+        /[(]\d{1,2}\/\d{1,2}\/\d{2,4}, \d{1,2}:\d{2}:\d{2} [A|P]M[)]$/g
+      );
+      let stringToReplace =
+        dateMatches && dateMatches.length
+          ? dateMatches[dateMatches.length - 1]
+          : "";
+      let date = `(${new Date().toLocaleString()})`;
+      newOp.name = stringToReplace
+        ? newOp.name.replace(stringToReplace, date)
+        : `${newOp.name} ${date}`;
+      try {
+        const response = await $api.post("/api/v2/operations", newOp);
+        this.selectedOperationID = response.data.id;
+        this.getOperations($api);
+      } catch (error) {
+        console.error("Error rerunning operation", error);
+      }
+    },
+    isOperationRunning() {
+      if (this.selectedOperationID === "") return false;
+      return !(
+        this.operations[this.selectedOperationID].state === "finished" ||
+        this.operations[this.selectedOperationID].state === "cleanup" ||
+        this.operations[this.selectedOperationID].state === "out_of_time"
+      );
+    },
+    async updateLink($api, status, command = null) {
+      const updatedLink = {
+        ...this.selectedLink,
+        command: b64DecodeUnicode(this.selectedLink.command),
+      };
+      if (command) updatedLink.command = command;
+      updatedLink.status = status;
+      try {
+        const response = await $api.patch(
+          `/api/v2/operations/${this.selectedOperationID}/links/${this.selectedLink.id}`,
+          updatedLink
+        );
+        await this.getOperations($api);
+        return response.data;
+      } catch (error) {
+        console.error("Error updating link state", error);
+      }
+    },
+    async addManualCommand($api, manualCommand) {
+      try {
+        const response = await $api.post(
+          `/api/v2/operations/${this.selectedOperationID}/potential-links`,
+          manualCommand
+        );
+        await this.getOperations($api);
+        return response.data;
+      } catch (error) {
+        console.error("Error adding manual command", error);
+      }
+    },
+    async addPotentialLinks($api, potentialLink) {
+      try {
+        for (let link of potentialLink) {
+          await $api.post(
+            `/api/v2/operations/${this.selectedOperationID}/potential-links`,
+            link
+          );
+        }
+        await this.getOperations($api);
+      } catch (error) {
+        console.error("Error adding potential links", error);
+      }
+    },
+    async getFacts($api) {
+      if (this.selectedOperationID === "") return;
+      try {
+        const response = await $api.get(
+          `/api/v2/facts/${this.selectedOperationID}`
+        );
+        this.facts = response.data.found;
+      } catch (error) {
+        console.error("Error getting facts");
+      }
+    },
+    async downloadOperationInfo($api, format, operationID, isAgentOutput) {
+      switch (format) {
+        case 0:
+          format = "report";
+          break;
+        case 1:
+          format = "event-logs";
+          break;
+        case 2:
+          format = "csv";
+          break;
+        default:
+          format = "report";
+          break;
+      }
+      if (format !== "csv") {
+        try {
+          const response = await $api.post(
+            `/api/v2/operations/${operationID}/${format}`,
+            { enable_agent_output: isAgentOutput }
+          );
+          const data = JSON.stringify(response.data);
+          const blob = new Blob([data], { type: "text/plain" });
+          this.createDownloadReport(blob, "json", format);
+        } catch (error) {
+          console.error("Error downloading operation", error);
+        }
+      } else {
+        let csv = [
+          "Time Ran,Ability Name,Agent,Host,pid,Link Command,Plaintext Command",
+        ];
+        this.operations[this.selectedOperationID].chain.forEach((link) => {
+          const rowItems = [];
+          rowItems.push(link.decide);
+          rowItems.push(link.ability.name);
+          rowItems.push(link.paw);
+          rowItems.push(link.host);
+          rowItems.push(link.pid);
+          rowItems.push(link.command);
+          rowItems.push(link.plaintext_command);
+          csv.push(rowItems.join(","));
+        });
+        const blob = new Blob([csv.join("\n")], { type: "text/csv" });
+        this.createDownloadReport(blob, "csv", format);
+      }
+    },
+    createDownloadReport(blob, fileName, format) {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.style.display = "none";
+      a.href = url;
+      a.download = `${
+        this.operations[this.selectedOperationID].name
+      }_${format}.${fileName}`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+    },
+  },
 });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,80 +1,87 @@
 export function getHumanFriendlyTime(date) {
-    if (!date) return '';
-    let split = date.split('-');
+  if (!date) return "";
+  let split = date.split("-");
 
-    let hMonth = Number(split[1]) - 1;
-    let hDate = Number(split[2].split(' ')[0]);
-    let hTime = split[2].split(' ')[1].split(':');
+  let hMonth = Number(split[1]) - 1;
+  let hDate = Number(split[2].split(" ")[0]);
+  let hTime = split[2].split(" ")[1].split(":");
 
-    const givenDate = Date.UTC(split[0], hMonth, hDate, hTime[0], hTime[1], hTime[2]);
-    // Make a fuzzy time
-    let delta = Math.round((Date.now() - givenDate) / 1000);
+  const givenDate = Date.UTC(
+    split[0],
+    hMonth,
+    hDate,
+    hTime[0],
+    hTime[1],
+    hTime[2]
+  );
+  // Make a fuzzy time
+  let delta = Math.round((Date.now() - givenDate) / 1000);
 
-    let minute = 60,
-        hour = minute * 60,
-        day = hour * 24;
+  let minute = 60,
+    hour = minute * 60,
+    day = hour * 24;
 
-    let fuzzy;
+  let fuzzy;
 
-    if (delta < 30) {
-        fuzzy = 'just now';
-    } else if (delta < minute) {
-        fuzzy = delta + ' seconds ago';
-    } else if (delta < 2 * minute) {
-        fuzzy = 'a minute ago'
-    } else if (delta < hour) {
-        fuzzy = Math.floor(delta / minute) + ' min ago';
-    } else if (Math.floor(delta / hour) === 1) {
-        fuzzy = '1 hr ago'
-    } else if (delta < day) {
-        fuzzy = Math.floor(delta / hour) + ' hrs ago';
-    } else if (delta < day * 2) {
-        fuzzy = 'yesterday ' + (hTime.join(':'));
-    } else {
-        switch (hMonth) {
-            case 0:
-                hMonth = 'Jan';
-                break;
-            case 1:
-                hMonth = 'Feb';
-                break;
-            case 2:
-                hMonth = 'Mar';
-                break;
-            case 3:
-                hMonth = 'Apr';
-                break;
-            case 4:
-                hMonth = 'May';
-                break;
-            case 5:
-                hMonth = 'Jun';
-                break;
-            case 6:
-                hMonth = 'Jul';
-                break;
-            case 7:
-                hMonth = 'Aug';
-                break;
-            case 8:
-                hMonth = 'Sep';
-                break;
-            case 9:
-                hMonth = 'Oct';
-                break;
-            case 10:
-                hMonth = 'Nov';
-                break;
-            case 11:
-                hMonth = 'Dec';
-                break;
-            default:
-                hMonth = '';
-                break;
-        }
-        fuzzy = hMonth + ' ' + hDate + ' ' + hTime.join(':');
+  if (delta < 30) {
+    fuzzy = "just now";
+  } else if (delta < minute) {
+    fuzzy = delta + " seconds ago";
+  } else if (delta < 2 * minute) {
+    fuzzy = "a minute ago";
+  } else if (delta < hour) {
+    fuzzy = Math.floor(delta / minute) + " min ago";
+  } else if (Math.floor(delta / hour) === 1) {
+    fuzzy = "1 hr ago";
+  } else if (delta < day) {
+    fuzzy = Math.floor(delta / hour) + " hrs ago";
+  } else if (delta < day * 2) {
+    fuzzy = "yesterday " + hTime.join(":");
+  } else {
+    switch (hMonth) {
+      case 0:
+        hMonth = "Jan";
+        break;
+      case 1:
+        hMonth = "Feb";
+        break;
+      case 2:
+        hMonth = "Mar";
+        break;
+      case 3:
+        hMonth = "Apr";
+        break;
+      case 4:
+        hMonth = "May";
+        break;
+      case 5:
+        hMonth = "Jun";
+        break;
+      case 6:
+        hMonth = "Jul";
+        break;
+      case 7:
+        hMonth = "Aug";
+        break;
+      case 8:
+        hMonth = "Sep";
+        break;
+      case 9:
+        hMonth = "Oct";
+        break;
+      case 10:
+        hMonth = "Nov";
+        break;
+      case 11:
+        hMonth = "Dec";
+        break;
+      default:
+        hMonth = "";
+        break;
     }
-    return fuzzy;
+    fuzzy = hMonth + " " + hDate + " " + hTime.join(":");
+  }
+  return fuzzy;
 }
 
 /**
@@ -83,31 +90,40 @@ export function getHumanFriendlyTime(date) {
  * @returns {string} - (i.e.) '5 hrs ago'
  */
 export function getHumanFriendlyTimeISO8601(dateTime) {
-	return getHumanFriendlyTime(dateTime.replace('T', ' ').replace('Z', ''));
+  return getHumanFriendlyTime(dateTime.replace("T", " ").replace("Z", ""));
 }
 
 export function getReadableTime(date) {
-    // i.e. format 2021-08-03 19:37:08
-    if (!date) return '';
-    date = date.replace('T', ' ').replace('Z', '');
-    let split = date.split('-');
+  // i.e. format 2021-08-03 19:37:08
+  if (!date) return "";
+  date = date.replace("T", " ").replace("Z", "");
+  let split = date.split("-");
 
-    let hMonth = Number(split[1]) - 1;
-    let hDate = Number(split[2].split(' ')[0]);
-    let hTime = split[2].split(' ')[1].split(':');
+  let hMonth = Number(split[1]) - 1;
+  let hDate = Number(split[2].split(" ")[0]);
+  let hTime = split[2].split(" ")[1].split(":");
 
-    return new Date(Date.UTC(split[0], hMonth, hDate, hTime[0], hTime[1], hTime[2])).toLocaleString('en-US', { timeZoneName: 'short' });
+  return new Date(
+    Date.UTC(split[0], hMonth, hDate, hTime[0], hTime[1], hTime[2])
+  ).toLocaleString("en-US", { timeZoneName: "short" });
 }
 
-export function b64DecodeUnicode(str) { //https://stackoverflow.com/a/30106551
-    if (str != null) {
-        // An error check is needed in case the wrong codec (i.e. not UTF-8) was used at source
-        try {
-            return decodeURIComponent(window.atob(str).split('').map(function (c) {
-                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-            }).join(''));
-        } catch {
-            return window.atob(str);
-        }
-    } else return "";
+export function b64DecodeUnicode(str) {
+  //https://stackoverflow.com/a/30106551
+  if (str != null) {
+    // An error check is needed in case the wrong codec (i.e. not UTF-8) was used at source
+    try {
+      return decodeURIComponent(
+        window
+          .atob(str)
+          .split("")
+          .map(function (c) {
+            return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+          })
+          .join("")
+      );
+    } catch {
+      return window.atob(str);
+    }
+  } else return "";
 }


### PR DESCRIPTION
This PR changes the operation page logic to use operation ID's to reference data instead of actual objects. This fixes all the state bug's we were encountering.

It also fixes the bug that didn't allow a user to view link commands and outputs.