### PR TITLE
Populate facts correctly when adding potential link and fix buggy command behavior 

### DIFF
--- a/src/components/abilities/CreateEditAbility.vue
+++ b/src/components/abilities/CreateEditAbility.vue
@@ -166,7 +166,7 @@ async function deleteAbility() {
                     .field
                         label.label Command
                         .control
-                            CodeEditor(v-model="executor.command" :key="executor.command + index" language="bash" line-numbers)
+                            CodeEditor(v-model="executor.command" :key="index" language="bash" line-numbers)
                     .field
                         label.label Timeout
                         .control
@@ -174,7 +174,7 @@ async function deleteAbility() {
                     label.label Cleanup
                     .field.has-addons(v-for="(cleanup, index) of executor.cleanup")
                         .control.is-expanded
-                            CodeEditor(v-model="executor.cleanup[index]" :key="executor.cleanup[index] + index" language="bash" line-numbers)
+                            CodeEditor(v-model="executor.cleanup[index]" :key="index" language="bash" line-numbers)
                         .control
                             a.button(@click="executor.cleanup.splice(index, 1)")
                                 span.icon

--- a/src/components/operations/AddPotentialLinkModal.vue
+++ b/src/components/operations/AddPotentialLinkModal.vue
@@ -61,14 +61,13 @@ const potentialLinksToAdd = computed(() => {
     }
 
     let combinations = [];
-    Object.keys(selectedPotentialLinkFacts.value).forEach((factName) => {
+    Object.keys(selectedPotentialLinkFacts.value).forEach((factName, i) => {
         combinations.push(selectedPotentialLinkFacts.value[factName].facts.filter((fact) => fact.selected).map((fact) => `${factName}|${fact.value}`));
         if (selectedPotentialLinkFacts.value[factName].customValue) {
-            combinations[0].push(`${factName}|${selectedPotentialLinkFacts.value[factName].customValue}`);
+            combinations[i].push(`${factName}|${selectedPotentialLinkFacts.value[factName].customValue}`);
         }
     });
     combinations = cartesian(combinations);
-
     let executor;
     if (selectedPotentialLink.value.executors) {
         executor = selectedPotentialLink.value.executors.find((e) => filters.executor === e.name);
@@ -106,7 +105,6 @@ const potentialLinksToAdd = computed(() => {
             }
         });
     });
-
     return links;
 });
 


### PR DESCRIPTION
Fixes #21 
Fixes #19 
This PR changes the key value for the code editor when creating an ability so Vue doesn't lose track causing buggy behavior.
It also corrects the index for custom value combinations when adding a potential link.