### PR TITLE
Reset scroll position when navigating between pages

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -100,6 +100,13 @@ const router = createRouter({
     },
     { path: "/:pathMatch(.*)*", name: "NotFound", component: NotFoundView },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    } else {
+      return { top: 0 };
+    }
+  },
 });
 
 router.beforeEach(async (to) => {


### PR DESCRIPTION
Closes #23 
This PR alters the Vue router to reset the browsers scroll position when navigating between pages unless the users uses popstate navigation (triggered by the browser's back/forward buttons). 