### PR TITLE
Fix approval in manual operations

### DIFF
--- a/src/components/operations/CommandPopup.vue
+++ b/src/components/operations/CommandPopup.vue
@@ -32,7 +32,7 @@ function isLinkEditable(currentLink) {
   return (
     operationStore.isOperationRunning() &&
     currentLink.status === -1 &&
-    !(currentLink.finish.length > 0 || currentLink.output === "True")
+    !(currentLink.finish || currentLink.output === "True")
   );
 }
 

--- a/src/components/operations/CommandPopup.vue
+++ b/src/components/operations/CommandPopup.vue
@@ -28,7 +28,6 @@ const isCommandObfuscated = computed(() => {
 
 function isLinkEditable(currentLink) {
   if (!currentLink) return false;
-  if (!currentLink.finish) return false;
   // Link can only be editable if operation is running, and if link is paused, queued, or completed
   return (
     operationStore.isOperationRunning() &&


### PR DESCRIPTION
Fixes mitre/caldera#2887.
Fixes and closes mitre/caldera#2962

Reasoning for the changes:
- deletion of line 31:
  - Just by thinking about it, this doesn't make much sense to me, since it basically means "if the link is not finished (does not have a finish date), it is not editable". This also goes against the comment that mentions that links in `paused` or `queued` can also be editable.
  - Secondly, this contradicts the last check, because we end up in this situation:
    - `(currentLink.finish = False) => (isEditable = False)` (from line 31)
    - `(currentLink.finish = True) => (isEditable = False)` (from line 36), assuming that `(currentLink.finish.length > 0) <=> (currentLink.finish)`. I assume this because I could only find any assignment to `link.finish` with the value of `get_current_timestamp()`. Since the initial value of `finish` is `None`, this would mean `finish` either has a value of `None` or a strictly not empty string. So right-to-left is True, with left-to-right being trivial.
    - **Assuming both propositions are true, we always have `isEditable = False`** (and thus the Approval is never possible).
- modification of line 36:
  - By reformulating `!(currentLink.finish.length > 0)`, we are checking that `currentLink.finish` is an empty string. But as explained before, this situation does not happen. If `finish` is not set, it has a value of `None/Null` and thus `.length` fails.

The only issue I could imagine with this fix is in the event of `finish` being able to reference an empty string for specific situations, but I did not find any trace of that ever happening.

Here's what a manual operation looks like with this change:
![image](https://github.com/mitre/magma/assets/168103052/f2f51430-a9ab-4f9d-a1f1-2993180cc6f6)

NB: as per mitre/caldera#2968, using this fix will in most cases trigger another error, but I chose to leave it separate as it's a different root cause with a different fix.