### PR TITLE
Fix encoding error in manually approved links

### DIFF
--- a/src/stores/operationStore.js
+++ b/src/stores/operationStore.js
@@ -109,7 +109,7 @@ export const useOperationStore = defineStore("operationStore", {
     async updateLink($api, status, command = null, currentLink) {
       const updatedLink = {
         ...currentLink,
-        command: b64DecodeUnicode(currentLink.command),
+        command: currentLink.command,
       };
       if (command) updatedLink.command = command;
       updatedLink.status = status;


### PR DESCRIPTION
Fixes mitre/caldera#2968

This is a... Very simple fix, maybe too simple, to the point that I'm wondering really hard what I could have missed.
Here's my reasoning: I do not discuss the implementation of `b64DecodeUnicode`, just its usage in this case, because the `command` that gets passed to `updateLink` is definitely not encoded in Base64.

With this change on top of mitre/magma#48, I am able to approve links in a manual operations and actually have them work.
![image](https://github.com/mitre/magma/assets/168103052/9ce248b7-c5d8-494a-afd7-4d4db729bf54)
