### PR TITLE
Harmonize requirements view in Ability creation/edition 

### DIFF
--- a/src/components/abilities/CreateEditAbility.vue
+++ b/src/components/abilities/CreateEditAbility.vue
@@ -220,6 +220,16 @@ async function deleteAbility() {
                                 input.input(type="text" v-model="abilityToEdit.requirements[index].module" placeholder="Requirement Module")
                             .field
                               span Source
+                              .field.has-addons(v-for="(relationship, r_index) of abilityToEdit.requirements[index].relationship_match")
+                                .field
+                                  .control
+                                    input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[r_index].source" placeholder="Source")
+                                .field
+                                  .control
+                                    input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[r_index].edge" placeholder="Edge [optional]")
+                                .field 
+                                  .control
+                                    input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[r_index].target" placeholder="Target [optional]")
                               .control
                                 input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].source" placeholder="Source")
                             .field

--- a/src/components/abilities/CreateEditAbility.vue
+++ b/src/components/abilities/CreateEditAbility.vue
@@ -224,7 +224,7 @@ async function deleteAbility() {
                                 input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].source" placeholder="Source")
                             .field
                               .control
-                                input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].edge" placeholder="Edge")
+                                input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].edge" placeholder="Edge [optional]")
                             .field
                               .control
                                 input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].target" placeholder="Target [optional]")

--- a/src/components/abilities/CreateEditAbility.vue
+++ b/src/components/abilities/CreateEditAbility.vue
@@ -230,14 +230,6 @@ async function deleteAbility() {
                                 .field 
                                   .control
                                     input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[r_index].target" placeholder="Target [optional]")
-                              .control
-                                input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].source" placeholder="Source")
-                            .field
-                              .control
-                                input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].edge" placeholder="Edge [optional]")
-                            .field
-                              .control
-                                input.input(type="text" v-model="abilityToEdit.requirements[index].relationship_match[0].target" placeholder="Target [optional]")
                           .control
                               a.button(@click="abilityToEdit.requirements.splice(index, 1)")
                                   span.icon


### PR DESCRIPTION
Harmonize the requirements view when creating/editing an ability, following #43 (shamelessly copied from this PR).
This makes it much easier to navigate in abilities with numerous requirements.

Before: 
![image](https://github.com/mitre/magma/assets/168103052/cb6e3133-e684-4a61-829e-dfbe19fb0808)

After (with a `--build`):
![image](https://github.com/mitre/magma/assets/168103052/1ab8d33f-899b-4613-823c-a40820a198a5)
