### PR TITLE
Feature - Manage payloads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -53,7 +53,7 @@ function promptToEnablePlugin(pluginName) {
           font-awesome-icon(icon="fas fa-user")
         span {{ version }}
     aside.menu(v-if="!userSettings.collapseNavigation")
-        
+
         p.menu-label
             font-awesome-icon(icon="fas fa-flag").pr-2
             | Campaigns
@@ -97,7 +97,7 @@ function promptToEnablePlugin(pluginName) {
             li
                 router-link.menu-item(to="/obfuscators") obfuscators
             li
-                a.menu-item(href="/api/docs" target="_blank") 
+                a.menu-item(href="/api/docs" target="_blank")
                     | api docs
                     font-awesome-icon(icon="fas fa-external-link-alt").pl-1.is-size-7
         ul.menu-list.has-text-centered.mt-2
@@ -154,7 +154,7 @@ function promptToEnablePlugin(pluginName) {
                 .dropdown-content.ml-2
                     router-link.dropdown-item(to="/planners") planners
                     router-link.dropdown-item(to="/obfuscators") obfuscators
-                    a.dropdown-item(href="/api/docs" target="_blank") 
+                    a.dropdown-item(href="/api/docs" target="_blank")
                         | api docs
                         font-awesome-icon(icon="fas fa-external-link-alt").pl-1.is-size-7
 

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -61,8 +61,6 @@ function promptToEnablePlugin(pluginName) {
             li
                 router-link.menu-item(to="/agents") agents
             li
-                router-link.menu-item(to="/payloads") payloads
-            li
                 router-link.menu-item(to="/abilities") abilities
             li
                 router-link.menu-item(to="/adversaries") adversaries
@@ -90,6 +88,8 @@ function promptToEnablePlugin(pluginName) {
                 router-link.menu-item(to="/contacts") contacts
             li
                 router-link.menu-item(to="/exfilledfiles") exfilled files
+            li
+                router-link.menu-item(to="/payloads") payloads
         p.menu-label
             font-awesome-icon(icon="fas fa-book").pr-2
             | Resources
@@ -121,7 +121,6 @@ function promptToEnablePlugin(pluginName) {
             .dropdown-menu(role="menu")
                 .dropdown-content.ml-2
                     router-link.dropdown-item(to="/agents") agents
-                    router-link.dropdown-item(to="/payloads") payloads
                     router-link.dropdown-item(to="/abilities") abilities
                     router-link.dropdown-item(to="/adversaries") adversaries
                     router-link.dropdown-item(to="/operations") operations
@@ -148,6 +147,7 @@ function promptToEnablePlugin(pluginName) {
                     router-link.dropdown-item(to="/objectives") objectives
                     router-link.dropdown-item(to="/contacts") contacts
                     router-link.dropdown-item(to="/exfilledfiles") exfilled files
+                    router-link.dropdown-item(to="/payloads") payloads
         .dropdown.is-hoverable.mb-2
             .dropdown-trigger
                 button.button(aria-haspopup="true" aria-controls="dropdown-menu")

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -61,6 +61,8 @@ function promptToEnablePlugin(pluginName) {
             li
                 router-link.menu-item(to="/agents") agents
             li
+                router-link.menu-item(to="/payloads") payloads
+            li
                 router-link.menu-item(to="/abilities") abilities
             li
                 router-link.menu-item(to="/adversaries") adversaries
@@ -119,6 +121,7 @@ function promptToEnablePlugin(pluginName) {
             .dropdown-menu(role="menu")
                 .dropdown-content.ml-2
                     router-link.dropdown-item(to="/agents") agents
+                    router-link.dropdown-item(to="/payloads") payloads
                     router-link.dropdown-item(to="/abilities") abilities
                     router-link.dropdown-item(to="/adversaries") adversaries
                     router-link.dropdown-item(to="/operations") operations

--- a/src/components/payloads/UploadModal.vue
+++ b/src/components/payloads/UploadModal.vue
@@ -41,24 +41,24 @@ async function submitFile($event) {
         header.modal-card-head
             p.modal-card-title Upload a payload
         .modal-card-body
-            .columns.is-vcentered
-                .column
-                    .file.has-name.is-fullwidth
-                        label.file-label
-                            input.file-input(type="file", ref="input", @change="updateFileName")
-                            span.file-cta
-                                span.file-icon
-                                    i.fas.fa-upload
-                                span.file-label Choose a file…
-                            span.file-name {{ fileName }}
-                .column.is-narrow
-                    button.button.is-primary(:disabled="!isFileSelected", @click="submitFile($event)") Upload
+            .file.has-name.is-fullwidth
+                label.file-label
+                    input.file-input(type="file", ref="input", @change="updateFileName")
+                    span.file-cta
+                        span.file-icon
+                            font-awesome-icon(icon="fas fa-upload")
+                        span.file-label Choose a file...
+                    span.file-name {{ fileName }}
         footer.modal-card-foot.is-flex.is-justify-content-flex-end
             button.button(@click="modals.payloads.showUpload = false") Close
+            button.button.is-primary(:disabled="!isFileSelected", @click="submitFile($event)")
+                span.icon
+                    font-awesome-icon(icon="fas fa-save")
+                span Upload
 </template>
 
 <style scoped>
 .modal-card{
-    width: 80%;
+    width: 70%;
 }
 </style>

--- a/src/components/payloads/UploadModal.vue
+++ b/src/components/payloads/UploadModal.vue
@@ -26,7 +26,7 @@ async function updateFileName($event) {
 
 async function submitFile($event) {
     const file = input.value.files[0];
-    await abilityStore.savePayload($api, file);
+    await abilityStore.savePayload($api, file, true, true);
 
     fileName.value = fileUploadPlaceholder;
     isFileSelected.value = false;

--- a/src/components/payloads/UploadModal.vue
+++ b/src/components/payloads/UploadModal.vue
@@ -56,3 +56,9 @@ async function submitFile($event) {
         footer.modal-card-foot.is-flex.is-justify-content-flex-end
             button.button(@click="modals.payloads.showUpload = false") Close
 </template>
+
+<style scoped>
+.modal-card{
+    width: 80%;
+}
+</style>

--- a/src/components/payloads/UploadModal.vue
+++ b/src/components/payloads/UploadModal.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { ref, inject} from "vue";
+import { useAbilityStore } from "../../stores/abilityStore";
+import { useCoreDisplayStore } from "../../stores/coreDisplayStore";
+import { storeToRefs } from "pinia";
+
+const $api = inject("$api");
+
+const abilityStore = useAbilityStore();
+const coreDisplayStore = useCoreDisplayStore();
+const { modals } = storeToRefs(coreDisplayStore);
+
+const fileUploadPlaceholder = "No file selected.";
+const fileName = ref(fileUploadPlaceholder);
+const isFileSelected = ref(false);
+const input = ref(null);
+
+async function updateFileName($event) {
+    if ($event.target.files.length > 0) {
+        fileName.value = $event.target.files[0].name;
+        isFileSelected.value = true;
+    } else {
+        isFileSelected.value = false;
+    }
+}
+
+async function submitFile($event) {
+    const file = input.value.files[0];
+    await abilityStore.savePayload($api, file);
+
+    fileName.value = fileUploadPlaceholder;
+    isFileSelected.value = false;
+    modals.value.payloads.showUpload = false;
+}
+</script>
+
+<template lang="pug">
+.modal(:class="{ 'is-active': modals.payloads.showUpload }")
+    .modal-background(@click="modals.payloads.showUpload = false")
+    .modal-card
+        header.modal-card-head
+            p.modal-card-title Upload a payload
+        .modal-card-body
+            .columns.is-vcentered
+                .column
+                    .file.has-name.is-fullwidth
+                        label.file-label
+                            input.file-input(type="file", ref="input", @change="updateFileName")
+                            span.file-cta
+                                span.file-icon
+                                    i.fas.fa-upload
+                                span.file-label Choose a file…
+                            span.file-name {{ fileName }}
+                .column.is-narrow
+                    button.button.is-primary(:disabled="!isFileSelected", @click="submitFile($event)") Upload
+        footer.modal-card-foot.is-flex.is-justify-content-flex-end
+            button.button(@click="modals.payloads.showUpload = false") Close
+</template>

--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import HomeView from "./views/HomeView.vue";
 import LoginView from "./views/LoginView.vue";
 import AgentsView from "./views/AgentsView.vue";
+import PayloadsView from "./views/PayloadsView.vue";
 import AbilitiesView from "./views/AbilitiesView.vue";
 import AdversariesView from "./views/AdversariesView.vue";
 import OperationsView from "./views/OperationsView.vue";
@@ -41,6 +42,11 @@ const router = createRouter({
       path: "/agents",
       name: "agents",
       component: AgentsView,
+    },
+    {
+      path: "/payloads",
+      name: "payloads",
+      component: PayloadsView,
     },
     {
       path: "/abilities",

--- a/src/stores/abilityStore.js
+++ b/src/stores/abilityStore.js
@@ -100,10 +100,11 @@ export const useAbilityStore = defineStore("abilityStore", {
                 console.error("Error uploading payload.", error);
             }
         },
-        async deletePayload($api, payloadName) {
+        async deletePayload($api, payloadName, addPath=false) {
             try {
                 await $api.delete(`/api/v2/payloads/${payloadName}`);
-                this.payloads.splice(this.payloads.findIndex((payload) => payload === payloadName), 1);
+                this.payloads.splice(this.payloads.findIndex((payload) =>
+                    (addPath ? payload.replace(/^data\/payloads\//, '') : payload) === payloadName), 1);
             } catch(error) {
                 console.error("Error deleting payload.", error);
             }

--- a/src/stores/abilityStore.js
+++ b/src/stores/abilityStore.js
@@ -76,7 +76,7 @@ export const useAbilityStore = defineStore("abilityStore", {
                 console.error("Error fetching payloads", error);
             }
         },
-        async savePayload($api, file) {
+        async savePayload($api, file, sort=false) {
             try {
                 let formData = new FormData();
                 formData.append("file", file);
@@ -85,7 +85,14 @@ export const useAbilityStore = defineStore("abilityStore", {
                         'Content-Type': 'multipart/form-data'
                     }
                 });
-                this.payloads.push(response.data["payloads"][0]);
+                let name = response.data["payloads"][0]
+                let index = sort ?
+                    this.payloads.findIndex((payload) => name.localeCompare(payload) < 0) : -1;
+                if (index === -1) {
+                    this.payloads.push(name);
+                } else {
+                    this.payloads.splice(index, 0, name);
+                }
             } catch(error) {
                 console.error("Error uploading payload.", error);
             }

--- a/src/stores/abilityStore.js
+++ b/src/stores/abilityStore.js
@@ -68,13 +68,35 @@ export const useAbilityStore = defineStore("abilityStore", {
                 console.error("Error fetching abilities", error);
             }
         },
-        async getPayloads($api) {
+        async getPayloads($api, sort=false, excludePlugins=false, addPath=false) {
             try {
-                const response = await $api.get("/api/v2/payloads");
+                const response = await $api.get("/api/v2/payloads", {params: {sort: sort, exclude_plugins: excludePlugins, add_path: addPath}});
                 this.payloads = response.data;
             } catch(error) {
                 console.error("Error fetching payloads", error);
             }
-        }
+        },
+        async savePayload($api, file) {
+            try {
+                let formData = new FormData();
+                formData.append("file", file);
+                const response = await $api.post(`/api/v2/payloads`, formData, {
+                    headers: {
+                        'Content-Type': 'multipart/form-data'
+                    }
+                });
+                this.payloads.push(response.data["payloads"][0]);
+            } catch(error) {
+                console.error("Error uploading payload.", error);
+            }
+        },
+        async deletePayload($api, payloadName) {
+            try {
+                await $api.delete(`/api/v2/payloads/${payloadName}`);
+                this.payloads.splice(this.payloads.findIndex((payload) => payload === payloadName), 1);
+            } catch(error) {
+                console.error("Error deleting payload.", error);
+            }
+        },
     },
 });

--- a/src/stores/abilityStore.js
+++ b/src/stores/abilityStore.js
@@ -76,7 +76,7 @@ export const useAbilityStore = defineStore("abilityStore", {
                 console.error("Error fetching payloads", error);
             }
         },
-        async savePayload($api, file, sort=false) {
+        async savePayload($api, file, sort=false, addPath=false) {
             try {
                 let formData = new FormData();
                 formData.append("file", file);
@@ -86,6 +86,9 @@ export const useAbilityStore = defineStore("abilityStore", {
                     }
                 });
                 let name = response.data["payloads"][0]
+                if (addPath) {
+                    name = "data/payloads/" + name;
+                }
                 let index = sort ?
                     this.payloads.findIndex((payload) => name.localeCompare(payload) < 0) : -1;
                 if (index === -1) {

--- a/src/stores/coreDisplayStore.js
+++ b/src/stores/coreDisplayStore.js
@@ -11,6 +11,9 @@ export const useCoreDisplayStore = defineStore("coreDisplayStore", {
           showConfig: false,
           showDetails: false,
         },
+        payloads: {
+          showUpload: false,
+        },
         adversaries: {
           showFactBreakdown: false,
           showImport: false,

--- a/src/tests/PayloadsView.test.js
+++ b/src/tests/PayloadsView.test.js
@@ -1,0 +1,15 @@
+import { mount } from "@vue/test-utils";
+import { axe, toHaveNoViolations } from "jest-axe";
+import PayloadsView from "../views/PayloadsView.vue";
+
+expect.extend(toHaveNoViolations);
+const wrapper = mount(PayloadsView);
+test("PayloadsView should have no accessibility violations", async () => {
+  const results = await axe(wrapper.element, {
+    // Set axe rules: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
+    rules: {
+      region: { enabled: false },
+    },
+  });
+  expect(results).toHaveNoViolations();
+});

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -58,9 +58,9 @@ hr
     h2 Local Payloads
     .columns.mb-4
         .column.is-one-quarter.is-flex.buttons.mb-0
-            button.button.is-primary.level-item(@click="modals.payloads.showUpload = true")
+            button.button(@click="modals.payloads.showUpload = true")
                 span.icon
-                    font-awesome-icon(icon="fas fa-plus")
+                    font-awesome-icon(icon="fas fa-file-import")
                 span Upload a payload
         .column.is-half.is-flex.is-justify-content-center
             span.tag.is-medium.m-0

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -46,7 +46,7 @@ table.table.is-striped.is-fullwidth.is-narrow
         tr.pointer(v-for="(payload, index) in payloads")
             td.is-four-fifths {{ payload }}
             td.has-text-centered
-                button.delete.is-white(@click.stop="abilityStore.deletePayload($api, payload, index)")
+                button.delete.is-white(@click.stop="abilityStore.deletePayload($api, payload, false)")
 
 //- Modals
 UploadModal

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted } from "vue";
+import { inject, onMounted, computed } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useCoreDisplayStore } from "@/stores/coreDisplayStore";
@@ -13,14 +13,39 @@ const coreDisplayStore = useCoreDisplayStore();
 const { payloads } = storeToRefs(abilityStore);
 const { modals } = storeToRefs(coreDisplayStore);
 
+const structuredPayloads = computed(() => {
+  const regex = /^(?:plugins\/([^/]+)|data)?\/payloads\/(.+)$/;
+  return payloads.value.map(payload => {
+    const match = payload.match(regex);
+    if (!match) {
+      console.error(`Payload path "${payload}" does not match the expected format.`);
+      return null;
+    }
+    let belongsToAPlugin = match[1] !== undefined;
+    return {
+      fullPath: payload,
+      belongsToAPlugin: match[1] !== undefined,
+      pluginName: match[1] || null,
+      fileName: match[2],
+    };
+  }).filter(Boolean);  // Remove null values
+});
+
+const pluginStructuredPayloads = computed(() => {
+  return structuredPayloads.value.filter(payload => payload.belongsToAPlugin);
+});
+
+const nonPluginStructuredPayloads = computed(() => {
+  return structuredPayloads.value.filter(payload => !payload.belongsToAPlugin);
+});
+
 onMounted(async () => {
-    await abilityStore.getPayloads($api, true, true, false);
+    await abilityStore.getPayloads($api, true, false, true);
 });
 
 </script>
 
 <template lang="pug">
-//- Header
 .content
     h2 Payloads
     p
@@ -29,29 +54,53 @@ onMounted(async () => {
         | You can only add or delete local payloads, not plugin ones.
 hr
 
-//- Button row
-.columns.mb-4
-    .column.is-one-quarter.is-flex.buttons.mb-0
-        button.button.is-primary.level-item(@click="modals.payloads.showUpload = true")
-            span.icon
-                font-awesome-icon(icon="fas fa-plus")
-            span Upload a payload
-    .column.is-half.is-flex.is-justify-content-center
-        span.tag.is-medium.m-0
-            span.has-text-success
-            strong {{ payloads.length }} payload{{ payloads.length === 0 || payloads.length > 1 ? 's' : '' }}
-table.table.is-striped.is-fullwidth.is-narrow
-    thead
-        tr
-            th name
-            th
-    tbody
-        tr.pointer(v-for="(payload, index) in payloads")
-            td.is-four-fifths {{ payload }}
-            td.has-text-centered
-                button.delete.is-white(@click.stop="abilityStore.deletePayload($api, payload, false)")
+.content
+    h2 Local Payloads
+    .columns.mb-4
+        .column.is-one-quarter.is-flex.buttons.mb-0
+            button.button.is-primary.level-item(@click="modals.payloads.showUpload = true")
+                span.icon
+                    font-awesome-icon(icon="fas fa-plus")
+                span Upload a payload
+        .column.is-half.is-flex.is-justify-content-center
+            span.tag.is-medium.m-0
+                span.has-text-success
+                strong
+                    | {{ nonPluginStructuredPayloads.length }}
+                    | payload{{ nonPluginStructuredPayloads.length === 0 || nonPluginStructuredPayloads.length > 1 ? 's' : '' }}
+    table.table.is-striped.is-fullwidth.is-narrow
+        thead
+            tr
+                th File name
+                th File path
+                th
+        tbody
+            tr.pointer(v-for="(payload, index) in nonPluginStructuredPayloads")
+                td {{ payload.fileName }}
+                td.is-four-fifths {{ payload.fullPath }}
+                td.has-text-centered
+                    button.delete.is-white(@click.stop="abilityStore.deletePayload($api, payload.fileName, true)")
 
-//- Modals
+.content
+    h2 Plugin Payloads
+    .columns.mb-4
+        .column.is-full.is-flex.is-justify-content-center
+            span.tag.is-medium.m-0
+                span.has-text-success
+                strong
+                    | {{ pluginStructuredPayloads.length }}
+                    | payload{{ pluginStructuredPayloads.length === 0 || pluginStructuredPayloads.length > 1 ? 's' : '' }}
+    table.table.is-striped.is-fullwidth.is-narrow
+        thead
+            tr
+                th File name
+                th File path
+                th Plugin Name
+        tbody
+            tr.pointer(v-for="payload in pluginStructuredPayloads")
+                td {{ payload.fileName }}
+                td.is-four-fifths {{ payload.fullPath }}
+                td {{ payload.pluginName }}
 UploadModal
 </template>
 

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { inject, onMounted } from "vue";
+import { storeToRefs } from "pinia";
+
+import { useCoreDisplayStore } from "@/stores/coreDisplayStore";
+import UploadModal from "@/components/payloads/UploadModal.vue";
+import { useAbilityStore } from "@/stores/abilityStore";
+
+const $api = inject("$api");
+
+const abilityStore = useAbilityStore();
+const coreDisplayStore = useCoreDisplayStore();
+const { payloads } = storeToRefs(abilityStore);
+const { modals } = storeToRefs(coreDisplayStore);
+
+onMounted(async () => {
+    await abilityStore.getPayloads($api, true, true, false);
+});
+
+</script>
+
+<template lang="pug">
+//- Header
+.content
+    h2 Payloads
+    p Payloads are any files that you can reference in ability executors. They are transferred to an agent which can then use them.
+hr
+
+//- Button row
+.columns.mb-4
+    .column.is-one-quarter.is-flex.buttons.mb-0
+        button.button.is-primary.level-item(@click="modals.payloads.showUpload = true")
+            span.icon
+                font-awesome-icon(icon="fas fa-plus")
+            span Upload a payload
+    .column.is-half.is-flex.is-justify-content-center
+        span.tag.is-medium.m-0
+            span.has-text-success
+            strong {{ payloads.length }} payload{{ payloads.length === 0 || payloads.length > 1 ? 's' : '' }}
+table.table.is-striped.is-fullwidth.is-narrow
+    thead
+        tr
+            th name
+            th
+    tbody
+        tr.pointer(v-for="(payload, index) in payloads")
+            td.is-four-fifths {{ payload }}
+            td.has-text-centered
+                button.delete.is-white(@click.stop="abilityStore.deletePayload($api, payload, index)")
+
+//- Modals
+UploadModal
+</template>
+
+<style scoped>
+tr {
+    cursor: pointer;
+}
+
+td.has-text-centered {
+    width: 40px;
+}
+</style>

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -23,7 +23,10 @@ onMounted(async () => {
 //- Header
 .content
     h2 Payloads
-    p Payloads are any files that you can reference in ability executors. They are transferred to an agent which can then use them.
+    p
+        | Payloads are any files that you can reference in ability executors.
+        | They are transferred to an agent which can then use them.<br/>
+        | You can only add or delete local payloads, not plugin ones.
 hr
 
 //- Button row


### PR DESCRIPTION
This is the GUI part of the payload management, which depends on the [Caldera PR #2989](https://github.com/mitre/caldera/pull/2989).

* **Adds a payload view**:
  * Accessible from the navigation menu,
  * Handles payload file upload to `data/payloads` (and deletion),
  * Plugins payloads are excluded and left intact,
* **Optional**: Removes some white spaces in `Navigation.vue`,
* **Optional**: Excludes JavaScript generated files form the Docker context:
  * Lighten the Docker context when building a Caldera image, when some generated JavaScript files are present (local development),
  * Exclude such files as the Dockerfile handles itself the Vue.js file compilation.