### PR TITLE
Rerun date string format

### DIFF
--- a/src/stores/operationStore.js
+++ b/src/stores/operationStore.js
@@ -76,13 +76,13 @@ export const useOperationStore = defineStore("operationStore", {
       let { id, start, state, chain, host_group, ...newOp } =
         this.operations[this.selectedOperationID];
       let dateMatches = newOp.name.match(
-        /[(]\d{1,2}\/\d{1,2}\/\d{2,4}, \d{1,2}:\d{2}:\d{2} [A|P]M[)]$/g
+        /[(]\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{1,3}Z[)]$/g
       );
       let stringToReplace =
         dateMatches && dateMatches.length
           ? dateMatches[dateMatches.length - 1]
           : "";
-      let date = `(${new Date().toLocaleString()})`;
+      let date = `(${new Date().toISOString()})`;
       newOp.name = stringToReplace
         ? newOp.name.replace(stringToReplace, date)
         : `${newOp.name} ${date}`;


### PR DESCRIPTION
The rerun date strings are using a US centric format, month / day / year, hour:minue:second AM/PM by utilizing the toLocaleString. 

I propose the use of ISO 8601 strings, much easier to read, and results in the operations to be sorted in a much more logical fashion. 

In the attached screenshot you can see that everything executed on 6/6 was in the afternoon, and sorts by date as anticipated. 

For 6/7,  the bottom couple entries aren't in chronological order. Addition of padding and removing AM/PM as done by ISO8601 should rectify this. 

![image](https://github.com/mitre/magma/assets/75033503/b6f2f7b7-56f4-440c-a7b4-f34a5e431421)
