### PR TITLE
Fix the Group field in Operation Details

### DIFF
--- a/src/components/operations/DetailsModal.vue
+++ b/src/components/operations/DetailsModal.vue
@@ -28,7 +28,7 @@ const operationStore = useOperationStore();
                         td {{`${operationStore.operations[operationStore.selectedOperationID].source.name}`}}
                     tr
                         th Group
-                        td {{operationStore.operations[operationStore.selectedOperationID].autonomous ? "all" : "red"}}
+                        td {{operationStore.operations[operationStore.selectedOperationID].group ? operationStore.operations[operationStore.selectedOperationID].group: "all"}}
                     tr
                         th Planner
                         td {{`${operationStore.operations[operationStore.selectedOperationID].planner.name}`}}

--- a/src/components/operations/DetailsModal.vue
+++ b/src/components/operations/DetailsModal.vue
@@ -28,7 +28,7 @@ const operationStore = useOperationStore();
                         td {{`${operationStore.operations[operationStore.selectedOperationID].source.name}`}}
                     tr
                         th Group
-                        td {{operationStore.operations[operationStore.selectedOperationID].group ? operationStore.operations[operationStore.selectedOperationID].group: "all"}}
+                        td {{operationStore.operations[operationStore.selectedOperationID].group || "all"}}
                     tr
                         th Planner
                         td {{`${operationStore.operations[operationStore.selectedOperationID].planner.name}`}}


### PR DESCRIPTION
Fixes mitre/caldera#3005: the Operation Details popup does not display the correct value when an operation has a specific agent group selected.

This field is currently filled this way:
`td {{operationStore.operations[operationStore.selectedOperationID].autonomous ? "all" : "red"}}`
But I don't see how the autonomous aspect of an operation correlates in any way to its target agent group, thus the suggested change.

Here's an operation created with the group "yellow" selected, before:
![image](https://github.com/mitre/magma/assets/168103052/b7d4c59c-d498-4d69-8934-310220e32c01)

and after:
![image](https://github.com/mitre/magma/assets/168103052/5ec6fd91-8410-430b-a1f2-f0a356be93d6)
