### PR TITLE
Fix parser button option name in operation creation modal

### DIFF
--- a/src/components/operations/CreateModal.vue
+++ b/src/components/operations/CreateModal.vue
@@ -189,7 +189,7 @@ async function createOperation() {
                         input.is-checkradio(type="radio" id="defaultparser" :checked="isDefParser" @click="isDefParser = true")
                         label.label.ml-3.mt-1(for="defaultparser") Use Default Parser
                         input.is-checkradio.ml-3(type="radio" id="nondefaultparser" :checked="!isDefParser" @click="isDefParser = false")
-                        label.label.ml-3.mt-1(for="nondefaultparser") Require manual approval
+                        label.label.ml-3.mt-1(for="nondefaultparser") Don't use default learning parsers
             .field.is-horizontal
                 .field-label 
                     label.label Auto Close


### PR DESCRIPTION
Fix copy-paste error for the button description to toggle whether or not to use default learning parsers when creating an operation