### PR TITLE
Allow incomplete fact selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview --port 5050",
     "lint": "npx eslint \"./**\"",
     "lintfix": "npx eslint \"./**\" --fix",
+    "test": "jest --config jest.config.js",
     "test-all": "jest --config jest.config.js && npx eslint \"./**\"",
     "test-accessibility": "jest -t=accessibility --config jest.config.js"
   },

--- a/src/components/operations/AddPotentialLinkModal.vue
+++ b/src/components/operations/AddPotentialLinkModal.vue
@@ -8,6 +8,7 @@ import { useOperationStore } from '@/stores/operationStore';
 import { useAgentStore } from "@/stores/agentStore";
 import { useAbilityStore } from "@/stores/abilityStore";
 import { useSourceStore } from "@/stores/sourceStore";
+import { cartesian } from "@/utils/utils";
 
 const props = defineProps({ 
     active: Boolean,
@@ -47,21 +48,8 @@ const filteredAbilities = computed(() => {
 
 const potentialLinksToAdd = computed(() => {
     let links = [];    
-    function cartesian(args) {
-        if (!args.length) return [];
-        let r = [], max = args.length - 1;
-        function helper(arr, i) {
-            for (let j = 0; j < args[i].length; j++) {
-                let a = arr.slice(0);
-                a.push(args[i][j]);
-                (i === max) ? r.push(a) : helper(a, i + 1);
-            }
-        }
-        helper([], 0);
-        return r;
-    }
-
     let combinations = [];
+
     Object.keys(selectedPotentialLinkFacts.value).forEach((factName, i) => {
         combinations.push(selectedPotentialLinkFacts.value[factName].facts.filter((fact) => fact.selected).map((fact) => `${factName.length}|${factName}${fact.value}`));
         if (selectedPotentialLinkFacts.value[factName].customValue) {

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -1,0 +1,37 @@
+import { cartesian } from '../utils/utils';
+
+describe('cartesian function', () => {
+  it('should return an empty array when input is empty', () => {
+    expect(cartesian([])).toEqual([]);
+  });
+
+  it('should return the correct cartesian product for non-empty arrays', () => {
+    const input = [[1, 2], [3, 4]];
+    const expectedOutput = [
+      [1, 3],
+      [1, 4],
+      [2, 3],
+      [2, 4]
+    ];
+    expect(cartesian(input)).toEqual(expectedOutput);
+  });
+
+  it('should allow arrays with empty sub-arrays', () => {
+    const input = [[1, 2], [], [3, 4]];
+    const expectedOutput = [
+      [1, 3],
+      [1, 4],
+      [2, 3],
+      [2, 4]
+    ];
+    expect(cartesian(input)).toEqual(expectedOutput);
+  });
+
+  it('should handle arrays with single elements', () => {
+    const input = [[1], [2], [3]];
+    const expectedOutput = [
+      [1, 2, 3]
+    ];
+    expect(cartesian(input)).toEqual(expectedOutput);
+  });
+});

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -127,3 +127,21 @@ export function b64DecodeUnicode(str) {
     }
   } else return "";
 }
+
+export function cartesian(args) {
+  // Remove empty arrays from the input
+  const filteredArgs = args.filter(arr => arr.length > 0);
+  if (!filteredArgs.length) return [];
+  let r = [], max = filteredArgs.length - 1;
+  
+  function helper(arr, i) {
+      for (const element of filteredArgs[i]) {
+          let a = arr.slice(0);
+          a.push(element);
+          (i === max) ? r.push(a) : helper(a, i + 1);
+      }
+  }
+  
+  helper([], 0);
+  return r;
+}


### PR DESCRIPTION
## Description

This change to the cartesian function allows a user to create a potential link without supplying values for every fact template.

If a fact template does not have a selected value, it is not replaced in the command. This is useful if the user has edited the command to remove a fact template. The change also allows for appropriate substitution of global facts (i.e. #{server}) when mixed with plugin facts.

fixes mitre/caldera#3030

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test added.

Integration tested by adding to a local instance of Caldera and replicating some representative use cases.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works