### PR TITLE
Remove VITE_CALDERA_URL and use window.location.origin to route API requests

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,0 @@
-VITE_CALDERA_URL=http://localhost:8888

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,6 @@ const app = createApp(App);
 const $api = axios.create({
   withCredentials: true,
 });
-if (import.meta.env.DEV) $api.defaults.baseURL = "http://localhost:8888";
 app.provide("$api", $api);
 
 app.use(createPinia());

--- a/src/router.js
+++ b/src/router.js
@@ -23,7 +23,7 @@ import NotFoundView from "./views/NotFoundView.vue";
 // Cant use global API variable because we aren't in a component
 const $api = axios.create({
   withCredentials: true,
-  baseURL: import.meta.env.VITE_CALDERA_URL || "http://localhost:8888",
+  baseURL: window.location.origin,
 });
 
 const router = createRouter({
@@ -113,11 +113,6 @@ const router = createRouter({
     {
       path: '/docs/index.html',
       beforeEnter: () => {
-        // Redirect to the external docs page
-        if (!import.meta.env.PROD) {
-          window.location.href = (import.meta.env.VITE_CALDERA_URL || 'http://localhost:8888') + '/docs/index.html';
-          return;
-        }
         window.location.href = '/docs/index.html';
       }
     },

--- a/src/views/ExfilledFilesView.vue
+++ b/src/views/ExfilledFilesView.vue
@@ -48,7 +48,7 @@ function downloadSelectedFiles() {
     let filename = filePath.split(/[\/\\]/);
     filename = filename[filename.length - 1];
     let uri = `${
-      import.meta.env.VITE_CALDERA_URL || "http://localhost:8888"
+      window.location.origin
     }/file/download_exfil?file=${btoa(filePath)}`;
     let downloadAnchorNode = document.createElement("a");
     downloadAnchorNode.setAttribute("href", uri);


### PR DESCRIPTION
Use `window.location.origin` to decide where to route API requests. 

VITE_CALDERA_URL adds complexity with no clear benefit. It is very easy to misconfigure (especially when magma was built outside of container, the .env file was changed, and then the Docker container was built). When it is misconfigured, there is no error and the UI just seems unresponsive.

Due to CORS and tight coupling between caldera and magma, it is very unlikely that the URL is going to be anything other than the value held in `window.location.origin`. In all other scenarios, a reverse proxy should be used.