### PR TITLE
using env variable rather than meta env for VITE_CALDERA_URL

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -23,7 +23,7 @@ import NotFoundView from "./views/NotFoundView.vue";
 // Cant use global API variable because we aren't in a component
 const $api = axios.create({
   withCredentials: true,
-  baseURL: import.meta.env.VITE_CALDERA_URL || "http://localhost:8888",
+  baseURL: process.env.VITE_CALDERA_URL || "http://localhost:8888",
 });
 
 const router = createRouter({

--- a/src/views/ExfilledFilesView.vue
+++ b/src/views/ExfilledFilesView.vue
@@ -48,7 +48,7 @@ function downloadSelectedFiles() {
     let filename = filePath.split(/[\/\\]/);
     filename = filename[filename.length - 1];
     let uri = `${
-      import.meta.env.VITE_CALDERA_URL || "http://localhost:8888"
+      process.env.VITE_CALDERA_URL || "http://localhost:8888"
     }/file/download_exfil?file=${btoa(filePath)}`;
     let downloadAnchorNode = document.createElement("a");
     downloadAnchorNode.setAttribute("href", uri);


### PR DESCRIPTION
Hi, 

I'm not a Vue developer, so I have no idea if what I've changed is actually correct. I'm running Caldera in a Docker container, and because of VITE_CALDERA_URL, the server pretty much hardcoded to http://localhost:8888. to change it, one must rebuild the whole frontend, which is not even possible through the container image. 

My thinking is, since you have a default address anyway, we can use `VITE_CALDERA_URL` as an environment variable, so the end user can dynamically change the base URL of Caldera and this frontend. 