### PR TITLE
Update RelationshipTable.vue

### DIFF
--- a/src/components/sources/RelationshipTable.vue
+++ b/src/components/sources/RelationshipTable.vue
@@ -45,21 +45,27 @@ async function saveRelationships() {
 table.table.is-striped.is-fullwidth
     thead
         tr
-            th Source
+            th Source Name
+            th Source Value
             th Edge
-            th Target
+            th Target Name
+            th Target Value
             th
     tbody
         tr(v-for="(relationship, index) of selectedSource.relationships")
-            td 
+            td
                 input.input(v-if="relationshipIndexToEdit === index" v-model="relationship.source.trait" placeholder="Relationship source")
                 span(v-else) {{ relationship.source.trait }}
-            td 
+            td
+                span {{ relationship.source.value }}
+            td
                 input.input(v-if="relationshipIndexToEdit === index" v-model="relationship.edge" placeholder="Relationship edge")
                 span(v-else) {{ relationship.edge }}
-            td 
+            td
                 input.input(v-if="relationshipIndexToEdit === index" v-model="relationship.target.trait" placeholder="Relationship target")
                 span(v-else) {{ relationship.target.trait }}
+            td
+               span {{ relationship.target.value }}
             td
                 .buttons
                     button.button.is-primary(


### PR DESCRIPTION
I've been spending some quality time in the fact sources (see https://github.com/mitre/caldera/issues/3177) and I'm more familiar with how they work now. Wanted to make the information that I've been dropping into a local debug log (fact names and associated values) visible in the UI. 

## Description

This updates the display on the factsources page. 
Previous version only had source edge and target, but did not include the values for the relationships. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Edited the Vue file locally, rebuilt and tested. Source and target values are now part of the output. See example. 

![image](https://github.com/user-attachments/assets/e32393e7-730e-43b9-9971-e3cfb5ce7294)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
