### PR TITLE
allow adversary save to persist between selections

### DIFF
--- a/src/components/adversaries/DetailsTable.vue
+++ b/src/components/adversaries/DetailsTable.vue
@@ -329,7 +329,7 @@ form.mb-4(v-else)
         .control
             input.input(v-model="selectedAdversary.description" placeholder="Adversary description")
     p.help.has-text-danger.mb-3(v-if="validation.name") {{ validation.name }}
-    button.button.is-primary(@click="isEditingName = false") Done
+    button.button.is-primary(type="button" @click="isEditingName = false") Done
 
 //- Button row
 .is-flex.is-align-items-center

--- a/src/stores/adversaryStore.js
+++ b/src/stores/adversaryStore.js
@@ -83,9 +83,9 @@ export const useAdversaryStore = defineStore("adversaryStore", {
           `/api/v2/adversaries/${this.selectedAdversary.adversary_id}`,
           reqBody
         );
-	if (response.status != 200) {
+	    if (response.status != 200) {
           throw new Error(`Non-200 HTTP response code from /api/v2/adversaries/${this.selectedAdversary.adversary_id}: ${response.status}`);
-	}
+	    }
         const index = this.adversaries.findIndex(
           (adversary) =>
             adversary.adversary_id === this.selectedAdversary.adversary_id

--- a/src/stores/adversaryStore.js
+++ b/src/stores/adversaryStore.js
@@ -83,11 +83,14 @@ export const useAdversaryStore = defineStore("adversaryStore", {
           `/api/v2/adversaries/${this.selectedAdversary.adversary_id}`,
           reqBody
         );
+	if (response.status != 200) {
+          throw new Error(`Non-200 HTTP response code from /api/v2/adversaries/${this.selectedAdversary.adversary_id}: ${response.status}`);
+	}
         const index = this.adversaries.findIndex(
           (adversary) =>
             adversary.adversary_id === this.selectedAdversary.adversary_id
         );
-        this.adversaries[index] = this.selectedAdversary;
+        this.adversaries[index] = response.data;
         return response.data;
       } catch (error) {
         console.error("Error saving adversary", error);


### PR DESCRIPTION
## Description
- fixes a UI bug where if you edit a new or existing adversary profile by adding/removing an ability, save changes, select a different adversary profile from the dropdown and then go back to the one you just edited (without changing caldera tabs or refreshing the page), the previous edits disappear
- also fixes the `Form submission canceled because the form is not connected` console warning message when setting the name and description for a new adversary.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Steps used to reproduce the bug (commit hash `d8115705362b4fba210f3ab691485aa178cc4e6a`):
- create a new adversary profile
- add an ability
- save the adversary profile
- select a different profile from the dropdown
- go back to the previously edited profile
- saved edits no longer appear

steps used to reproduce the bug with existing adversary profiles:
- select an existing profile
- add or remove an ability
- save the adversary profile
- select a different profile from the dropdown
- go back to the previously edited profile
- saved edits no longer appear

Same steps were used on the bug-fix branch to verify that edits persist in the UI as expected.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
