### PR TITLE
Use API to kill agent, fetch agent status from server

### DIFF
--- a/src/components/agents/DetailsModal.vue
+++ b/src/components/agents/DetailsModal.vue
@@ -3,6 +3,7 @@ import { inject, reactive } from "vue";
 import { useAgentStore } from "../../stores/agentStore";
 import { useCoreDisplayStore } from "../../stores/coreDisplayStore";
 import { storeToRefs } from "pinia";
+import { getAgentStatus } from "@/utils/agentUtil.js";
 
 const $api = inject("$api");
 
@@ -16,20 +17,6 @@ let validation = reactive({
     beaconTimer: "",
     watchdogTimer: ""
 });
-
-function getAgentStatus(agent) {
-    if (!agent.last_seen) return '';
-    let lastSeen = new Date(agent.last_seen).getTime();
-    let msSinceSeen = Date.now() - lastSeen;
-    // Give a buffer of 1 minute to mark an agent dead
-    let isAlive = (msSinceSeen < (agent.sleep_max * 1000));
-
-    if (msSinceSeen <= 60000 && agent.sleep_min === 3 && agent.sleep_max === 3 && agent.watchdog === 1) {
-        return 'pending kill'
-    } else {
-        return msSinceSeen <= 60000 || isAlive ? 'alive' : 'dead';
-    }
-}
 
 function saveAgent() {
     // Validate group

--- a/src/components/operations/AgentDetailsModal.vue
+++ b/src/components/operations/AgentDetailsModal.vue
@@ -3,6 +3,7 @@ import { inject, reactive, ref } from "vue";
 import { useAgentStore } from "../../stores/agentStore";
 import { useCoreDisplayStore } from "../../stores/coreDisplayStore";
 import { storeToRefs } from "pinia";
+import { getAgentStatus } from "@/utils/agentUtil.js";
 
 const $api = inject("$api");
 
@@ -18,25 +19,6 @@ let validation = reactive({
 });
 let showDetails = ref(false);
 let showActions = ref(false);
-
-function getAgentStatus(agent) {
-  if (!agent.last_seen) return "";
-  let lastSeen = new Date(agent.last_seen).getTime();
-  let msSinceSeen = Date.now() - lastSeen;
-  // Give a buffer of 1 minute to mark an agent dead
-  let isAlive = msSinceSeen < agent.sleep_max * 1000;
-
-  if (
-    msSinceSeen <= 60000 &&
-    agent.sleep_min === 3 &&
-    agent.sleep_max === 3 &&
-    agent.watchdog === 1
-  ) {
-    return "pending kill";
-  } else {
-    return msSinceSeen <= 60000 || isAlive ? "alive" : "dead";
-  }
-}
 
 function saveAgent() {
   // Validate group

--- a/src/stores/agentStore.js
+++ b/src/stores/agentStore.js
@@ -57,13 +57,8 @@ export const useAgentStore = defineStore("agentStore", {
             }
         },
         async killAgent($api, agentPaw) {
-            const reqBody = {
-                watchdog: 1,
-                sleep_min: 3,
-                sleep_max: 3
-            };
             try {
-                const response = await $api.patch(`/api/v2/agents/${agentPaw}`, reqBody);
+                const response = await $api.post(`/api/v2/agents/kill/${agentPaw}`);
                 return response.data;
             } catch(error) {
                 throw error;

--- a/src/utils/agentUtil.js
+++ b/src/utils/agentUtil.js
@@ -3,15 +3,5 @@ export {
 };
 
 function getAgentStatus(agent) {
-    if (!agent.last_seen) return '';
-    let lastSeen = new Date(agent.last_seen).getTime();
-    let msSinceSeen = Date.now() - lastSeen;
-    // Give a buffer of 1 minute to mark an agent dead
-    let isAlive = (msSinceSeen < (agent.sleep_max * 1000));
-
-    if (msSinceSeen <= 60000 && agent.sleep_min === 3 && agent.sleep_max === 3 && agent.watchdog === 1) {
-        return 'pending kill'
-    } else {
-        return msSinceSeen <= 60000 || isAlive ? 'alive' : 'dead';
-    }
+    return agent.status;
 }


### PR DESCRIPTION
## Description
- Use the new `POST /api/v2/agents/kill/{paw}` endpoint to kill agents
- Don't calculate agent status via browser side, rather get it from the server itself

Requires https://github.com/mitre/caldera/pull/3249

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran agents, tested killing them and letting them time out


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
