### PR TITLE
Add architecture field in agent modal

### DIFF
--- a/src/components/agents/DeployModal.vue
+++ b/src/components/agents/DeployModal.vue
@@ -149,7 +149,9 @@ function copyCommandToClipboard(command) {
                             label.label {{ field.name }}
                         .field-body
                             .field.has-addons
-                                .control.is-expanded
+                                .control.is-expanded(v-if="field.name === 'agents.architecture'")
+                                    input.input(type="text" v-tooltip="'e.g. 386, amd64, arm64, wasm, etc.'" v-model="field.value")
+                                .control.is-expanded(v-else)
                                     input.input(type="text" v-model="field.value")
                                 .control 
                                     a.button.has-tooltip-arrow(title="Reset to default" @click="field.value = agentFieldConfig[field.name]")


### PR DESCRIPTION
## Description

Related changes in agent repos and core Caldera will add a new input field to some agent deployment commands in the agent deployment modal. This PR adds a tooltip with common examples.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the server, opened the modal and inspected visually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
