### PR TITLE
fix: prevent dual-value submission in Add Potential Link modal

### DIFF
--- a/src/components/operations/AddPotentialLinkModal.vue
+++ b/src/components/operations/AddPotentialLinkModal.vue
@@ -99,6 +99,21 @@ const potentialLinksToAdd = computed(() => {
 
 const canSelectAgent = computed(() => !props.agent || !props.agent.paw);
 
+// When a custom value is typed, deselect all fact checkboxes for that fact name
+function onCustomValueInput(factName) {
+    selectedPotentialLinkFacts.value[factName].facts.forEach((fact) => {
+        fact.selected = false;
+    });
+}
+
+// When a fact checkbox is selected, clear the custom value for that fact name
+function onFactSelected(factName) {
+    const hasSelected = selectedPotentialLinkFacts.value[factName].facts.some((fact) => fact.selected);
+    if (hasSelected) {
+        selectedPotentialLinkFacts.value[factName].customValue = "";
+    }
+}
+
 const operationSourceFacts = computed(() => props.operation?.source?.facts || []);
 
 onMounted(async () => {
@@ -246,10 +261,10 @@ const selectPotentialLink = async (link) => {
                             v-tooltip="`There are currently empty fact templates. You can still add this link but it may not run properly.`")
                             font-awesome-icon(icon="fa-exclamation-triangle")
                     .control
-                        input.input(v-model="selectedPotentialLinkFacts[factName].customValue" type="text" placeholder="Enter a custom value")
+                        input.input(v-model="selectedPotentialLinkFacts[factName].customValue" type="text" placeholder="Enter a custom value" @input="onCustomValueInput(factName)")
                     div(v-for="fact in selectedPotentialLinkFacts[factName].facts")
                         label.checkbox
-                            input.mr-2(type="checkbox" v-model="fact.selected")
+                            input.mr-2(type="checkbox" v-model="fact.selected" @change="onFactSelected(factName)")
                             span.mr-2 {{ fact.value }}
                             span.tag.mr-2 {{ fact.origin }}
     


### PR DESCRIPTION
## Summary

Closes #22

When adding a potential link, if a user both types a custom value **and** selects a fact source checkbox for the same fact template, multiple unexpected links are queued. This is unintuitive — only one value type should apply per fact at a time.

## Changes

- When a fact checkbox is selected, the custom value input for that fact is cleared
- When a custom value is typed into the input, all fact checkboxes for that fact are deselected

This mirrors the behavior described in #22: selecting a fact source removes the custom value, and typing a custom value unselects any checked facts.

## How Has This Been Tested?

Manually verified in the Add Potential Link modal:
- Typing a custom value while a fact checkbox is checked → checkboxes are cleared
- Checking a fact checkbox while a custom value is present → custom value is cleared
- Only one link is now queued per fact instead of multiple

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)