### PR TITLE
fix: preserve tab state when switching between views

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,9 @@ onMounted(() => {
         PageTabs
 
         .p-4#router
-            router-view
+            router-view(v-slot="{ Component }")
+                KeepAlive
+                    component(:is="Component")
 </template>
 
 <style scoped>

--- a/src/views/AbilitiesView.vue
+++ b/src/views/AbilitiesView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from "pinia";
-import { reactive, ref, inject, onMounted, computed } from "vue";
+import { reactive, ref, inject, onMounted, onActivated, computed } from "vue";
 import { useRoute } from "vue-router";
 import { useAbilityStore } from "@/stores/abilityStore";
 import { getAbilityPlatforms } from "@/utils/abilityUtil.js";
@@ -37,6 +37,10 @@ const filteredAbilities = computed(() => {
 onMounted(async () => {
     await abilityStore.getAbilities($api);
     filters.plugin = route.query.plugin || "";
+});
+
+onActivated(async () => {
+    await abilityStore.getAbilities($api);
 });
 
 function clearFilters() {

--- a/src/views/AdversariesView.vue
+++ b/src/views/AdversariesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, reactive, ref, onMounted, computed } from "vue";
+import { inject, reactive, ref, onMounted, onActivated, computed } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useAdversaryStore } from "@/stores/adversaryStore";
@@ -26,6 +26,12 @@ let filteredAdversaries = computed(() => {
 });
 
 onMounted(async () => {
+    await abilityStore.getAbilities($api);
+    await adversaryStore.getAdversaries($api);
+    await objectiveStore.getObjectives($api);
+});
+
+onActivated(async () => {
     await abilityStore.getAbilities($api);
     await adversaryStore.getAdversaries($api);
     await objectiveStore.getObjectives($api);

--- a/src/views/AgentsView.vue
+++ b/src/views/AgentsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted, onBeforeUnmount, ref } from "vue";
+import { inject, onMounted, onActivated, onDeactivated, ref } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useAgentStore } from '@/stores/agentStore';
@@ -26,9 +26,16 @@ onMounted(async () => {
     }, 3000);
 });
 
-onBeforeUnmount(() => {
+onActivated(async () => {
+    await agentStore.getAgents($api);
+    agentRefreshInterval.value = setInterval(async () => {
+        await agentStore.getAgents($api);
+    }, 3000);
+});
+
+onDeactivated(() => {
     clearInterval(agentRefreshInterval.value);
-})
+});
 
 function removeDeadAgents() {
     agents.value.forEach((agent, index) => {

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted } from "vue";
+import { inject, onMounted, onActivated } from "vue";
 import { useCoreStore } from "../stores/coreStore";
 import { storeToRefs } from "pinia";
 
@@ -10,6 +10,11 @@ const { contacts } = storeToRefs(coreStore);
 const { availableContacts } = storeToRefs(coreStore);
 
 onMounted(async () => {
+  await coreStore.getContacts($api);
+  await coreStore.getAvailableContacts($api);
+});
+
+onActivated(async () => {
   await coreStore.getContacts($api);
   await coreStore.getAvailableContacts($api);
 });

--- a/src/views/ExfilledFilesView.vue
+++ b/src/views/ExfilledFilesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { reactive, ref, inject, onMounted, watch } from "vue";
+import { reactive, ref, inject, onMounted, onActivated, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useCoreStore } from "@/stores/coreStore";
 import { useOperationStore } from "@/stores/operationStore";
@@ -27,6 +27,11 @@ onMounted(async () => {
   Object.keys(files).forEach((agentName) => {
     folderState[agentName] = false;
   });
+});
+
+onActivated(async () => {
+  await operationStore.getOperations($api);
+  exfilStore.loadFiles($api, selectedOperationId.value);
 });
 
 function toggleAllFiles() {

--- a/src/views/FactSourcesView.vue
+++ b/src/views/FactSourcesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, inject, onMounted } from "vue";
+import { ref, inject, onMounted, onActivated } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useSourceStore } from "@/stores/sourceStore.js";
@@ -16,6 +16,10 @@ let isEditingName = ref(false);
 let newSourceName = ref("");
 
 onMounted(() => {
+  sourceStore.getSources($api);
+});
+
+onActivated(() => {
   sourceStore.getSources($api);
 });
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -6,11 +6,19 @@ import AdversaryChartStatus from "@/components/adversaries/AdversaryChartStatus.
 import CodeEditor from "@/components/core/CodeEditor.vue";
 import { useCoreStore } from "@/stores/coreStore";
 import { storeToRefs } from "pinia";
-import { onMounted, inject } from "vue";
+import { onMounted, onActivated, inject } from "vue";
 
 const coreStore = useCoreStore();
 const $api = inject("$api");
 onMounted(async () => {
+  try {
+    await coreStore.getMainConfig($api);
+  } catch (error) {
+    console.error(error);
+  }
+});
+
+onActivated(async () => {
   try {
     await coreStore.getMainConfig($api);
   } catch (error) {

--- a/src/views/ObfuscatorsView.vue
+++ b/src/views/ObfuscatorsView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from "pinia";
-import { inject, onMounted } from "vue";
+import { inject, onMounted, onActivated } from "vue";
 import { useCoreStore } from "../stores/coreStore";
 
 const coreStore = useCoreStore();
@@ -9,6 +9,10 @@ const { obfuscators } = storeToRefs(coreStore);
 const $api = inject("$api");
 
 onMounted(async () => {
+    await coreStore.getObfuscators($api);
+});
+
+onActivated(async () => {
     await coreStore.getObfuscators($api);
 });
 </script>

--- a/src/views/ObjectivesView.vue
+++ b/src/views/ObjectivesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, inject, onMounted } from "vue";
+import { ref, inject, onMounted, onActivated } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useAdversaryStore } from "@/stores/adversaryStore.js";
@@ -15,6 +15,10 @@ let newObjectiveName = ref("");
 let newObjectiveDescription = ref("");
 
 onMounted(async () => {
+    await adversaryStore.getObjectives($api);
+});
+
+onActivated(async () => {
     await adversaryStore.getObjectives($api);
 });
 

--- a/src/views/OperationsView.vue
+++ b/src/views/OperationsView.vue
@@ -3,7 +3,8 @@ import {
   inject,
   ref,
   onMounted,
-  onBeforeUnmount,
+  onActivated,
+  onDeactivated,
   computed,
   watch,
   reactive,
@@ -179,7 +180,14 @@ onMounted(async () => {
   selectOperation();
 });
 
-onBeforeUnmount(() => {
+onActivated(async () => {
+  await operationStore.getOperations($api);
+  await agentStore.getAgents($api);
+  agentStore.updateAgentGroups();
+  selectOperation();
+});
+
+onDeactivated(() => {
   if (updateInterval) clearInterval(updateInterval);
 });
 

--- a/src/views/PayloadsView.vue
+++ b/src/views/PayloadsView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted, computed } from "vue";
+import { inject, onMounted, onActivated, computed } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useCoreDisplayStore } from "@/stores/coreDisplayStore";
@@ -40,6 +40,10 @@ const nonPluginStructuredPayloads = computed(() => {
 });
 
 onMounted(async () => {
+    await abilityStore.getPayloads($api, true, false, true);
+});
+
+onActivated(async () => {
     await abilityStore.getPayloads($api, true, false, true);
 });
 

--- a/src/views/PlannersView.vue
+++ b/src/views/PlannersView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from "pinia";
-import { inject, onMounted } from "vue";
+import { inject, onMounted, onActivated } from "vue";
 import { useCoreStore } from "../stores/coreStore";
 
 const coreStore = useCoreStore();
@@ -9,6 +9,10 @@ const { planners } = storeToRefs(coreStore);
 const $api = inject("$api");
 
 onMounted(async () => {
+    await coreStore.getPlanners($api);
+});
+
+onActivated(async () => {
     await coreStore.getPlanners($api);
 });
 </script>

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, inject, onMounted } from 'vue';
+import { computed, inject, onMounted, onActivated } from 'vue';
 import { storeToRefs } from "pinia";
 
 import CreateScheduleModal from "@/components/schedules/CreateScheduleModal.vue";
@@ -29,6 +29,12 @@ const handleClick = (id) => {
 onMounted(async () => {
   await scheduleStore.getSchedules($api);
   await coreStore.getObfuscators($api);
+  await agentStore.getAgents($api);
+  agentStore.updateAgentGroups();
+});
+
+onActivated(async () => {
+  await scheduleStore.getSchedules($api);
   await agentStore.getAgents($api);
   agentStore.updateAgentGroups();
 });

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from "pinia";
-import { ref, inject, onMounted, computed, watch } from "vue";
+import { ref, inject, onMounted, onActivated, computed, watch } from "vue";
 import { useCoreStore } from "../stores/coreStore";
 
 const coreStore = useCoreStore();
@@ -17,6 +17,10 @@ watch(mainConfig, () => {
 });
 
 onMounted(async () => {
+    await coreStore.getMainConfig($api);
+});
+
+onActivated(async () => {
     await coreStore.getMainConfig($api);
 });
 


### PR DESCRIPTION
## Summary
- Wraps `<router-view>` with `<KeepAlive>` to preserve component state across tab switches
- Filters, selections, and scroll positions are now preserved when navigating away and back
- Adds `onActivated` hooks to refresh data from API when returning to a tab
- Migrates polling intervals to `onActivated`/`onDeactivated` to stop background polling on inactive tabs

## Test plan
- [ ] Switch from Abilities (with filters set) to Operations and back — filters should persist
- [ ] Switch from Operations (with operation selected) to Agents and back — operation selection should persist
- [ ] Create a new ability in one tab, switch to Operations and back to Abilities — new ability should appear
- [ ] Verify agent polling stops when leaving Agents tab (check network tab)
- [ ] Verify operation polling stops when leaving Operations tab