### PR TITLE
Refresh abilities and adversaries dynamically in Adversary view

### DIFF
--- a/src/components/abilities/AbilitySelection.vue
+++ b/src/components/abilities/AbilitySelection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed, inject, onMounted } from 'vue';
+import { ref, reactive, computed, inject, onMounted, watch } from 'vue';
 import { storeToRefs } from "pinia";
 
 import { useAbilityStore } from "@/stores/abilityStore";
@@ -41,6 +41,15 @@ const hasFiltersApplied = computed(() => {
 
 onMounted(async () => {
     await abilityStore.getAbilities($api);
+});
+
+// Re-fetch abilities every time the modal is opened so newly created
+// abilities (e.g. from another tab or the Abilities view) appear
+// immediately without requiring a page reload.
+watch(() => props.active, async (isActive) => {
+    if (isActive) {
+        await abilityStore.getAbilities($api);
+    }
 });
 
 function clearFilters() {

--- a/src/views/AdversariesView.vue
+++ b/src/views/AdversariesView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, reactive, ref, onMounted, computed } from "vue";
+import { inject, reactive, ref, onMounted, onActivated, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 
 import { useAdversaryStore } from "@/stores/adversaryStore";
@@ -29,6 +29,23 @@ onMounted(async () => {
     await abilityStore.getAbilities($api);
     await adversaryStore.getAdversaries($api);
     await objectiveStore.getObjectives($api);
+});
+
+// When the view is re-activated via KeepAlive (e.g. switching tabs),
+// refresh all data so new abilities and adversaries appear immediately.
+onActivated(async () => {
+    await abilityStore.getAbilities($api);
+    await adversaryStore.getAdversaries($api);
+    await objectiveStore.getObjectives($api);
+});
+
+// Refresh the adversary list when the dropdown opens so that adversaries
+// created or modified on disk (by plugins, imports, etc.) are visible
+// without leaving and returning to the page.
+watch(isAdversaryDropdownOpen, async (isOpen) => {
+    if (isOpen) {
+        await adversaryStore.getAdversaries($api);
+    }
 });
 
 function selectAdversary(adversary) {


### PR DESCRIPTION
## Summary
- **AbilitySelection.vue**: Re-fetch abilities from the API each time the ability picker modal opens, so newly created abilities are immediately visible without page reload
- **AdversariesView.vue**: Refresh abilities, adversaries, and objectives on KeepAlive re-activation (`onActivated`) and refresh the adversary list when the selection dropdown opens
- Companion to mitre/caldera#3344 which adds server-side file watching for adversary YAML changes

## Problem
In the Adversary view:
1. New abilities created while editing an adversary were not visible in the ability picker until leaving and returning to the page
2. Adversary YAML files updated on disk (by plugins, imports, or manual edits) were not reflected in the dropdown
3. The ability list was fetched once on mount and cached for the component lifetime

## Test plan
- [ ] Open Adversary view, navigate to Abilities view, create a new ability, return to Adversary view — new ability should appear in picker
- [ ] Open the ability picker modal, close it, create a new ability via API, reopen the picker — new ability should appear
- [ ] Modify an adversary YAML on disk, open the adversary dropdown — updated adversary should appear
- [ ] Verify no duplicate API calls on initial page load (onActivated does not fire on first mount)