### PR TITLE
fix: dynamic data refresh across all stores and modals

### DIFF
--- a/src/components/operations/AddPotentialLinkModal.vue
+++ b/src/components/operations/AddPotentialLinkModal.vue
@@ -1,5 +1,5 @@
  <script setup>
-import { inject, ref, onMounted, reactive, computed } from "vue";
+import { inject, ref, onMounted, reactive, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { toast } from 'bulma-toast'
 
@@ -10,7 +10,7 @@ import { useAbilityStore } from "@/stores/abilityStore";
 import { useSourceStore } from "@/stores/sourceStore";
 import { cartesian } from "@/utils/utils";
 
-const props = defineProps({ 
+const props = defineProps({
     active: Boolean,
     operation: Object,
     agent: Object
@@ -24,6 +24,20 @@ const agentStore = useAgentStore();
 const abilityStore = useAbilityStore();
 const sourceStore = useSourceStore();
 const { sources } = storeToRefs(sourceStore);
+
+// Re-fetch abilities and agents when the modal is opened
+watch(
+    () => props.active,
+    async (newValue) => {
+        if (newValue) {
+            await Promise.all([
+                abilityStore.getAbilities($api),
+                agentStore.getAgents($api),
+                sourceStore.getSources($api),
+            ]);
+        }
+    }
+);
 
 let selectedPotentialLink = ref({});
 let selectedPotentialLinkFacts = ref({});

--- a/src/components/operations/CreateModal.vue
+++ b/src/components/operations/CreateModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, inject, onMounted } from "vue";
+import { ref, inject, onMounted, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { toast } from 'bulma-toast';
 import { sanitizeInput, validateInput } from "@/utils/sanitize";
@@ -45,14 +45,29 @@ let validation = ref({
     name: "",
 });
 
+async function refreshDropdownData() {
+    await Promise.all([
+        agentStore.getAgents($api),
+        adversaryStore.getAdversaries($api),
+        getSources(),
+        coreStore.getObfuscators($api),
+        getPlanners(),
+    ]);
+}
+
 onMounted(async () => {
-    await agentStore.getAgents($api);
-    agentStore.updateAgentGroups();
-    await adversaryStore.getAdversaries($api);
-    await getSources();
-    await coreStore.getObfuscators($api);
-    await getPlanners();
+    await refreshDropdownData();
 });
+
+// Re-fetch all dropdown data when the modal is opened
+watch(
+    () => modals.value.operations.showCreate,
+    async (newValue) => {
+        if (newValue) {
+            await refreshDropdownData();
+        }
+    }
+);
 
 async function getSources() {
     try {

--- a/src/components/schedules/CreateScheduleModal.vue
+++ b/src/components/schedules/CreateScheduleModal.vue
@@ -42,19 +42,26 @@ let validation = ref({
   name: "",
 });
 
+async function refreshDropdownData() {
+  await Promise.all([
+    agentStore.getAgents($api),
+    adversaryStore.getAdversaries($api),
+    getSources(),
+    coreStore.getObfuscators($api),
+    getPlanners(),
+  ]);
+}
+
 onMounted(async () => {
-  await agentStore.getAgents($api);
-  agentStore.updateAgentGroups();
-  await adversaryStore.getAdversaries($api);
-  await getSources();
-  await coreStore.getObfuscators($api);
-  await getPlanners();
+  await refreshDropdownData();
 });
 
+// Re-fetch all dropdown data and reset fields when the modal is opened
 watch(
   () => modals.value.schedules.showCreate,
-  (newValue) => {
+  async (newValue) => {
     if (newValue) {
+      await refreshDropdownData();
       resetFields();
     }
   }

--- a/src/stores/adversaryStore.js
+++ b/src/stores/adversaryStore.js
@@ -63,7 +63,7 @@ export const useAdversaryStore = defineStore("adversaryStore", {
         this.adversaries.push(response.data);
         this.adversaries.sort((a, b) => a.name > b.name);
         this.selectedAdversary = response.data;
-        this.updateSelectedAdversaryAbilities();
+        this.updateSelectedAdversaryAbilities($api);
       } catch (error) {
         console.error("Error creating an adversary", error);
       }
@@ -112,19 +112,24 @@ export const useAdversaryStore = defineStore("adversaryStore", {
         console.error("Error deleting adversary", error);
       }
     },
-    updateSelectedAdversaryAbilities() {
+    async updateSelectedAdversaryAbilities($api) {
       if (!this.selectedAdversary.atomic_ordering) {
         this.selectedAdversaryAbilities = [];
-      } else {
-        this.selectedAdversaryAbilities =
-          this.selectedAdversary.atomic_ordering.map((ability_id) => {
-            return {
-              ...abilityStore().abilities.find(
-                (ability) => ability.ability_id === ability_id
-              ),
-            };
-          });
+        return;
       }
+      // Re-fetch abilities to ensure we have the latest data
+      if ($api) {
+        await abilityStore().getAbilities($api);
+      }
+      this.selectedAdversaryAbilities =
+        this.selectedAdversary.atomic_ordering
+          .map((ability_id) => {
+            const found = abilityStore().abilities.find(
+              (ability) => ability.ability_id === ability_id
+            );
+            return found ? { ...found } : null;
+          })
+          .filter((ability) => ability !== null);
     },
   },
 });

--- a/src/stores/agentStore.js
+++ b/src/stores/agentStore.js
@@ -6,8 +6,14 @@ export const useAgentStore = defineStore("agentStore", {
             agents: [],
             agentConfig: {},
             selectedAgent: {},
-            agentGroups: []
         };
+    },
+
+    getters: {
+        agentGroups: (state) => {
+            if (!state.agents) return [];
+            return [...new Set(state.agents.map((agent) => agent.group))];
+        },
     },
 
     actions: {
@@ -64,9 +70,6 @@ export const useAgentStore = defineStore("agentStore", {
                 throw error;
             }
         },
-        updateAgentGroups() {
-            if (!this.agents) return;
-            this.agentGroups = [...new Set(this.agents.map((agent) => agent.group))];
-        }
+        // agentGroups is now a getter derived from agents state
     },
 });

--- a/src/views/AdversariesView.vue
+++ b/src/views/AdversariesView.vue
@@ -33,7 +33,7 @@ onMounted(async () => {
 
 function selectAdversary(adversary) {
     selectedAdversary.value = adversary; 
-    adversaryStore.updateSelectedAdversaryAbilities();
+    adversaryStore.updateSelectedAdversaryAbilities($api);
     isAdversaryDropdownOpen.value = false;
     adversarySearchQuery.value = "";
 }

--- a/src/views/OperationsView.vue
+++ b/src/views/OperationsView.vue
@@ -45,6 +45,7 @@ const coreStore = useCoreStore();
 const { modals } = storeToRefs(coreDisplayStore);
 
 let updateInterval = ref();
+let operationsListInterval = ref();
 let showPotentialLinkModal = ref(false);
 let selectedOutputLink = ref(null);
 
@@ -175,12 +176,18 @@ onMounted(async () => {
   await operationStore.getOperations($api);
   await coreStore.getObfuscators($api);
   await agentStore.getAgents($api);
-  agentStore.updateAgentGroups();
+  // agentGroups is now a computed getter, no manual update needed
   selectOperation();
+
+  // Periodically refresh the operations list to pick up new/changed operations
+  operationsListInterval.value = setInterval(async () => {
+    await operationStore.getOperations($api);
+  }, 15000);
 });
 
 onBeforeUnmount(() => {
   if (updateInterval) clearInterval(updateInterval);
+  if (operationsListInterval.value) clearInterval(operationsListInterval.value);
 });
 
 const resetFilter = () => {

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -30,7 +30,7 @@ onMounted(async () => {
   await scheduleStore.getSchedules($api);
   await coreStore.getObfuscators($api);
   await agentStore.getAgents($api);
-  agentStore.updateAgentGroups();
+  // agentGroups is now a computed getter, no manual update needed
 });
 </script>
 


### PR DESCRIPTION
## Summary
- **Agent groups as computed getter (D2):** `agentGroups` is now a Pinia getter derived from `agents` state, eliminating the need for manual `updateAgentGroups()` calls and ensuring groups are always in sync with the agent list.
- **Operations CreateModal re-fetches on open (E1):** Added a `watch` on `modals.operations.showCreate` that re-fetches agents, adversaries, sources, obfuscators, and planners when the modal opens, so dropdowns always show fresh data.
- **Schedules CreateModal re-fetches on open (E2):** Same pattern applied to the schedule creation modal — dropdown data is refreshed every time the modal becomes visible.
- **AddPotentialLinkModal re-fetches on open (E3):** Added a `watch` on the `active` prop that re-fetches abilities, agents, and sources when the modal opens.
- **Adversary ability mapping null guard (E4):** `updateSelectedAdversaryAbilities()` now filters out `null` results from stale/deleted ability IDs and optionally re-fetches abilities from the server when `$api` is available.
- **Operations list periodic refresh (D1):** Added a 15-second interval in `OperationsView` that refreshes the full operations list, so new or externally-modified operations appear without page navigation.

## Files changed
- `src/stores/agentStore.js` — `agentGroups` moved from state to getter; removed `updateAgentGroups()` action
- `src/stores/adversaryStore.js` — `updateSelectedAdversaryAbilities()` now async with null guard and optional re-fetch
- `src/components/operations/CreateModal.vue` — watch on modal visibility to re-fetch dropdown data
- `src/components/schedules/CreateScheduleModal.vue` — watch on modal visibility to re-fetch dropdown data
- `src/components/operations/AddPotentialLinkModal.vue` — watch on `active` prop to re-fetch abilities/agents
- `src/views/OperationsView.vue` — 15s operations list refresh interval
- `src/views/AdversariesView.vue` — pass `$api` to updated `updateSelectedAdversaryAbilities()`
- `src/views/SchedulesView.vue` — removed stale `updateAgentGroups()` call

## Test plan
- [ ] Open the Operations CreateModal after adding a new agent — verify the new agent's group appears in the dropdown
- [ ] Open the Schedules CreateModal after adding a new adversary — verify it appears in the adversary dropdown
- [ ] Open AddPotentialLinkModal — verify abilities list is current
- [ ] Select an adversary that references a deleted ability — verify no crash, missing abilities are silently filtered
- [ ] Create an operation via API while the Operations page is open — verify it appears in the dropdown within 15 seconds
- [ ] Verify no console errors during normal navigation between views