### PR TITLE
feat(ui): add community feedback banner to login view

### DIFF
--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -68,12 +68,15 @@ async function handleLogin(e) {
 
 .feedback-banner a {
     color: #4A90E2;
-    text-decoration: none;
+    text-decoration: underline;
     transition: opacity 0.2s;
 }
 
-.feedback-banner a:hover {
+.feedback-banner a:hover,
+.feedback-banner a:focus-visible {
     opacity: 0.8;
     text-decoration: underline;
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
 }
 </style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -37,6 +37,14 @@ async function handleLogin(e) {
             button.button.fancy-button.is-fullwidth(type="submit" @click="handleLogin") Log In
         .has-text-danger
             p {{ loginError }}
+        .feedback-banner.has-text-centered.is-size-7.mt-5.pt-4
+            p.mb-1.has-text-grey
+                | Help us improve Caldera! Let us know what you think.
+                | Send feedback to 
+                a(href="mailto:caldera@mitre.org") caldera@mitre.org
+            p.has-text-grey
+                | For the latest information and support, join our 
+                a(href="https://discord.gg/mJsTuhZ88T" target="_blank" rel="noopener noreferrer") Discord Community
 </template>
 
 <style scoped>
@@ -52,5 +60,20 @@ async function handleLogin(e) {
 .fancy-button:hover {
     background-image: linear-gradient(to right, #8b0000, #191970) !important;
     border-width: 2px;
+}
+
+.feedback-banner {
+    border-top: 1px solid rgba(128, 128, 128, 0.2);
+}
+
+.feedback-banner a {
+    color: #4A90E2;
+    text-decoration: none;
+    transition: opacity 0.2s;
+}
+
+.feedback-banner a:hover {
+    opacity: 0.8;
+    text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
## Description
This PR introduces a lightweight community feedback banner to the Magma login screen (`LoginView.vue`). 

## Motivation and Context
To improve user engagement and streamline support, this banner provides direct, visible links to the official `caldera@mitre.org` feedback email and the Caldera Discord community. Placing this on the login screen ensures users know exactly where to find help, report issues, or engage with the community before they even authenticate into the platform.

## Changes Made
* Modified `plugins/magma/src/views/LoginView.vue`.
* Appended a `feedback-banner` element to the Pug template, positioned unobtrusively below the login form.
* Utilized native styling (`has-text-grey`, `is-size-7`, etc.) to ensure the banner blends seamlessly with the existing Caldera UI design language.
* Added standard `target="_blank"` and `rel="noopener noreferrer"` attributes to external links for security.

## How Has This Been Tested?
* Confirmed the template compiles cleanly via `npm run build` and `npm run dev`.
* Visually verified the layout, spacing, and link functionality on the local development server. 
* Verified the banner dynamically scales and does not break the vertical centering of the main login container.