### PR TITLE
feat(ui): add automatic version check notification to navigation

### DIFF
--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -44,9 +44,21 @@ function promptToEnablePlugin(pluginName) {
 async function checkGitHubVersion() {
     try {
         const response = await fetch("https://api.github.com/repos/mitre/caldera/releases/latest");
+
+        if (!response.ok) {
+            console.warn("Failed to fetch Caldera version from GitHub:", response.status, response.statusText);
+            return;
+        }
+
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.toLowerCase().includes("application/json")) {
+            console.warn("Unexpected response type when fetching Caldera version from GitHub:", contentType);
+            return;
+        }
+
         const data = await response.json();
-        
-        if (data.tag_name) {
+
+        if (typeof data.tag_name === "string") {
             const githubVersion = data.tag_name.replace('v', '');
             latestVersion.value = githubVersion;
             releaseUrl.value = data.html_url;

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject } from "vue";
+import { inject, ref, onMounted } from "vue";
 import { storeToRefs } from "pinia";
 import { useRoute, useRouter } from "vue-router";
 import { useCoreStore } from "@/stores/coreStore";
@@ -19,6 +19,10 @@ const router = useRouter();
 
 const $api = inject("$api");
 
+const hasUpdate = ref(false);
+const latestVersion = ref("");
+const releaseUrl = ref("");
+
 try {
   await coreStore.getAvailablePlugins($api);
   await coreStore.getMainConfig($api);
@@ -36,6 +40,29 @@ function promptToEnablePlugin(pluginName) {
   this.modals.core.selectedPlugin = pluginName;
   this.modals.core.showPluginPopup = true;
 }
+
+async function checkGitHubVersion() {
+    try {
+        const response = await fetch("https://api.github.com/repos/mitre/caldera/releases/latest");
+        const data = await response.json();
+        
+        if (data.tag_name) {
+            const githubVersion = data.tag_name.replace('v', '');
+            latestVersion.value = githubVersion;
+            releaseUrl.value = data.html_url;
+
+            if (githubVersion !== version.value) {
+                hasUpdate.value = true;
+            }
+        }
+    } catch (error) {
+        console.error("Failed to fetch Caldera version from GitHub:", error);
+    }
+}
+
+onMounted(() => {
+    checkGitHubVersion();
+});
 </script>
 
 <template lang="pug">
@@ -51,7 +78,16 @@ function promptToEnablePlugin(pluginName) {
       div.team-container
         span.icon(:class="{ 'is-red': group === 'RED', 'is-blue': group === 'BLUE'}")
           font-awesome-icon(icon="fas fa-user")
-        span {{ version }}
+          
+        span(v-if="!hasUpdate") {{ version }}
+        
+        a.has-text-warning.has-text-weight-bold(
+          v-else
+          :href="releaseUrl" 
+          target="_blank" 
+          rel="noopener noreferrer"
+          :title="'View release notes for ' + latestVersion"
+        ) {{ version }} (Update)
     aside.menu(v-if="!userSettings.collapseNavigation")
 
         p.menu-label

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -11,14 +11,10 @@ const authStore = useAuthStore();
 const coreDisplayStore = useCoreDisplayStore();
 const coreStore = useCoreStore();
 const { modals } = storeToRefs(coreDisplayStore);
-const { enabledPlugins, availablePlugins, userSettings, hideDisabledPlugins } =
-  storeToRefs(coreStore);
+const { enabledPlugins, availablePlugins, userSettings, hideDisabledPlugins } = storeToRefs(coreStore);
 const { group, version } = storeToRefs(authStore);
-
 const router = useRouter();
-
 const $api = inject("$api");
-
 const hasUpdate = ref(false);
 const latestVersion = ref("");
 const releaseUrl = ref("");
@@ -65,12 +61,10 @@ async function checkGitHubVersion() {
     const cachedUrl = localStorage.getItem(URL_CACHE_KEY);
     const cachedTime = localStorage.getItem(TIME_CACHE_KEY);
 
-    // 1. Avoid Rate Limits: Check cache before making external requests
     if (cachedVersion && cachedUrl && cachedTime && (now - parseInt(cachedTime) < TTL_MS)) {
         latestVersion.value = cachedVersion;
         releaseUrl.value = cachedUrl;
         
-        // 2. Semantic comparison: Only alert if GitHub is strictly newer
         if (isNewerVersion(cachedVersion, version.value)) {
             hasUpdate.value = true;
         }
@@ -102,7 +96,6 @@ async function checkGitHubVersion() {
             localStorage.setItem(URL_CACHE_KEY, data.html_url);
             localStorage.setItem(TIME_CACHE_KEY, now.toString());
 
-            // 2. Semantic comparison: Only alert if GitHub is strictly newer
             if (isNewerVersion(githubVersion, version.value)) {
                 hasUpdate.value = true;
             }
@@ -252,7 +245,6 @@ onMounted(() => {
                         | api docs
                         font-awesome-icon(icon="fas fa-external-link-alt").pl-1.is-size-7
 
-//- Modals
 PluginModal
 </template>
 

--- a/src/components/core/Navigation.vue
+++ b/src/components/core/Navigation.vue
@@ -41,9 +41,44 @@ function promptToEnablePlugin(pluginName) {
   this.modals.core.showPluginPopup = true;
 }
 
+function isNewerVersion(remote, local) {
+    const rParts = remote.split('.').map(Number);
+    const lParts = local.split('.').map(Number);
+    
+    for (let i = 0; i < Math.max(rParts.length, lParts.length); i++) {
+        const r = rParts[i] || 0;
+        const l = lParts[i] || 0;
+        if (r > l) return true;
+        if (r < l) return false;
+    }
+    return false;
+}
+
 async function checkGitHubVersion() {
+    const CACHE_KEY = "calderaGitHubVersion";
+    const URL_CACHE_KEY = "calderaGitHubReleaseUrl";
+    const TIME_CACHE_KEY = "calderaGitHubVersionTime";
+    const TTL_MS = 1000 * 60 * 60 * 24; // 24 hours in milliseconds
+
+    const now = Date.now();
+    const cachedVersion = localStorage.getItem(CACHE_KEY);
+    const cachedUrl = localStorage.getItem(URL_CACHE_KEY);
+    const cachedTime = localStorage.getItem(TIME_CACHE_KEY);
+
+    // 1. Avoid Rate Limits: Check cache before making external requests
+    if (cachedVersion && cachedUrl && cachedTime && (now - parseInt(cachedTime) < TTL_MS)) {
+        latestVersion.value = cachedVersion;
+        releaseUrl.value = cachedUrl;
+        
+        // 2. Semantic comparison: Only alert if GitHub is strictly newer
+        if (isNewerVersion(cachedVersion, version.value)) {
+            hasUpdate.value = true;
+        }
+        return;
+    }
+
     try {
-        const response = await fetch("https://api.github.com/repos/mitre/caldera/releases/latest");
+        const response = await fetch("https://api.github.com/repos/apache/caldera/releases/latest");
 
         if (!response.ok) {
             console.warn("Failed to fetch Caldera version from GitHub:", response.status, response.statusText);
@@ -55,7 +90,6 @@ async function checkGitHubVersion() {
             console.warn("Unexpected response type when fetching Caldera version from GitHub:", contentType);
             return;
         }
-
         const data = await response.json();
 
         if (typeof data.tag_name === "string") {
@@ -63,7 +97,13 @@ async function checkGitHubVersion() {
             latestVersion.value = githubVersion;
             releaseUrl.value = data.html_url;
 
-            if (githubVersion !== version.value) {
+            // Update localStorage cache
+            localStorage.setItem(CACHE_KEY, githubVersion);
+            localStorage.setItem(URL_CACHE_KEY, data.html_url);
+            localStorage.setItem(TIME_CACHE_KEY, now.toString());
+
+            // 2. Semantic comparison: Only alert if GitHub is strictly newer
+            if (isNewerVersion(githubVersion, version.value)) {
                 hasUpdate.value = true;
             }
         }


### PR DESCRIPTION
## Description

This PR introduces an automated, silent version checker to the Magma sidebar (`Navigation.vue`) that alerts users when a newer release of Caldera is available on GitHub.

## Type of change

- [*] New feature (non-breaking change which adds functionality)
  * Modified `plugins/magma/src/components/Navigation.vue`.
  * Added an asynchronous background fetch to the public GitHub API (`api.github.com/repos/mitre/caldera/releases/latest`) using the `onMounted` hook.
  * Evaluates the local `version` store against the latest GitHub release tag.
  * If an update exists, the static version span dynamically transforms into a clickable warning link (e.g., `5.3.0 (Update)`).
  * Designed to maximize tight sidebar real-estate by reusing the version text rather than adding bulky icons.

## Graceful Degradation (Offline Support)

* The API call is wrapped in a `try...catch` block. 
* If the Caldera server is running in an air-gapped environment, behind a strict NAT, or if the GitHub API rate limit is hit, the network error is silently caught in the console. 
* The UI gracefully falls back to displaying the static local version number with zero workflow interruption for the user.

## How Has This Been Tested?

* Compiled locally via `npm run build`.
* Hardcoded local state to force a version mismatch and verified the conditional UI renders correctly, matches Caldera's warning text styling, and links out accurately.
* Simulated an offline environment to verify the `catch` block successfully intercepts the fetch failure and renders the standard static span.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
