### PR TITLE
ci: fix update-dist checkout for fork PRs

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -16,8 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        fetch-depth: '0'
-        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
## Summary
- Drop `ref: ${{ github.event.pull_request.head.ref }}` from the checkout step in `update-dist.yml`. That ref doesn't resolve for cross-repo (forked) PRs and breaks the job (e.g. job `71128207893`).
- Unquote `fetch-depth: 0`.

With this change, `actions/checkout@v5` uses the default merge ref, which is fetched for both same-repo and forked PRs.

## Test plan
- [ ] Re-run the `Update dist` workflow on PR #106 (forked PR — `clutester:fix/axios-cve-update`) and confirm the checkout step succeeds.