### PR TITLE
feat(ui): add warning before editing agent

### DIFF
--- a/src/components/agents/DetailsModal.vue
+++ b/src/components/agents/DetailsModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, reactive } from "vue";
+import { inject, reactive, ref, computed, watch } from "vue";
 import { useAgentStore } from "../../stores/agentStore";
 import { useCoreDisplayStore } from "../../stores/coreDisplayStore";
 import { storeToRefs } from "pinia";
@@ -11,11 +11,35 @@ const agentStore = useAgentStore();
 const { selectedAgent } = storeToRefs(agentStore);
 const coreDisplayStore = useCoreDisplayStore();
 const { modals } = storeToRefs(coreDisplayStore);
+const originalAgent = ref(null);
 
 let validation = reactive({
     group: "",
     beaconTimer: "",
     watchdogTimer: ""
+});
+
+function setOriginalAgent() {
+    if (selectedAgent.value) {
+        // Deep clone to remove reactivity from the snapshot
+        originalAgent.value = JSON.parse(JSON.stringify(selectedAgent.value));
+    }
+}
+
+watch(() => selectedAgent.value?.paw, (newPaw) => {
+    if (newPaw) {
+        setOriginalAgent();
+    }
+}, { immediate: true });
+
+function isDirty(field) {
+    if (!originalAgent.value || !selectedAgent.value) return false;
+    return selectedAgent.value[field] !== originalAgent.value[field];
+}
+
+const hasAnyChanges = computed(() => {
+    const fieldsToCheck = ['pending_contact', 'group', 'sleep_min', 'sleep_max', 'watchdog'];
+    return fieldsToCheck.some(field => isDirty(field));
 });
 
 function saveAgent() {
@@ -46,7 +70,17 @@ function saveAgent() {
 
     // If all inputs pass validation, save
     if (!validation.group && !validation.beaconTimer && !validation.watchdogTimer) {
+        if (hasAnyChanges.value) {
+            const confirmed = window.confirm("Changes to agents affect all Caldera users!\n\nAre you sure you want to save these changes?");
+            
+            // Abort the save if they click 'Cancel'
+            if (!confirmed) {
+                return; 
+            }
+        }
         agentStore.saveSelectedAgent($api);
+        // Reset the baseline after a successful save so the yellow boxes go back to normal
+        setOriginalAgent();
     }
 }
 </script>
@@ -66,27 +100,27 @@ function saveAgent() {
                     tr
                         th.has-text-right Contact
                         td
-                            .select.control
+                            .select.control(:class="{ 'is-warning': isDirty('pending_contact') }")
                                 select(v-model="selectedAgent.pending_contact")
                                     option(v-for="contact in selectedAgent.available_contacts" :key="contact" :value="contact") {{ contact }}
                     tr
                         th.has-text-right Group 
                         td
-                            input.input(type="text" v-model="selectedAgent.group" :class="{ 'is-danger': validation.group }")
+                            input.input(type="text" v-model="selectedAgent.group" :class="{ 'is-danger': validation.group, 'is-warning': isDirty('group') }")
                             p.help.has-text-danger(v-if="validation.group") {{ validation.group }}
                     tr 
                         th.has-text-right Sleep Timer
                         td
                             .is-flex.is-align-items-center 
                                 label.mr-3 min
-                                input.input.mr-4(v-model="selectedAgent.sleep_min" type="number" placeholder="30" min="0" :max="selectedAgent.sleep_max" :class="{ 'is-danger': validation.beaconTimer }")
+                                input.input.mr-4(v-model="selectedAgent.sleep_min" type="number" placeholder="30" min="0" :max="selectedAgent.sleep_max" :class="{ 'is-danger': validation.beaconTimer, 'is-warning': isDirty('sleep_min') }")
                                 label.mr-3 max
-                                input.input(v-model="selectedAgent.sleep_max" type="number" placeholder="60" :min="selectedAgent.sleep_min" :class="{ 'is-danger': validation.beaconTimer }")
+                                input.input(v-model="selectedAgent.sleep_max" type="number" placeholder="60" :min="selectedAgent.sleep_min" :class="{ 'is-danger': validation.beaconTimer, 'is-warning': isDirty('sleep_max') }")
                             p.help.has-text-danger(v-if="validation.beaconTimer") {{ validation.beaconTimer }}
                     tr
                         th.has-text-right Watchdog Timer
                         td
-                            input.input(type="number" v-model="selectedAgent.watchdog" min="0" :class="{ 'is-danger': validation.watchdogTimer }")
+                            input.input(type="number" v-model="selectedAgent.watchdog" min="0" :class="{ 'is-danger': validation.watchdogTimer, 'is-warning': isDirty('watchdog') }")
                             p.help.has-text-danger(v-if="validation.watchdogTimer") {{ validation.watchdogTimer }}
             button.button.is-primary.is-fullwidth.mt-4(@click="saveAgent()") Save Settings
             hr

--- a/src/components/agents/DetailsModal.vue
+++ b/src/components/agents/DetailsModal.vue
@@ -32,6 +32,12 @@ watch(() => selectedAgent.value?.paw, (newPaw) => {
     }
 }, { immediate: true });
 
+watch(() => modals.value?.agents?.showDetails, (showDetails) => {
+    if (showDetails && selectedAgent.value) {
+        setOriginalAgent();
+    }
+});
+
 function isDirty(field) {
     if (!originalAgent.value || !selectedAgent.value) return false;
     return selectedAgent.value[field] !== originalAgent.value[field];

--- a/src/components/agents/DetailsModal.vue
+++ b/src/components/agents/DetailsModal.vue
@@ -40,7 +40,15 @@ watch(() => modals.value?.agents?.showDetails, (showDetails) => {
 
 function isDirty(field) {
     if (!originalAgent.value || !selectedAgent.value) return false;
-    return selectedAgent.value[field] !== originalAgent.value[field];
+
+    const numericFields = new Set(['sleep_min', 'sleep_max', 'watchdog']);
+    const currentValue = selectedAgent.value[field];
+    const originalValue = originalAgent.value[field];
+    if (numericFields.has(field)) {
+        return Number(currentValue) !== Number(originalValue);
+    }
+    
+    return currentValue !== originalValue;
 }
 
 const hasAnyChanges = computed(() => {
@@ -87,6 +95,10 @@ function saveAgent() {
         agentStore.saveSelectedAgent($api);
         // Reset the baseline after a successful save so the yellow boxes go back to normal
         setOriginalAgent();
+        // Close the modal after saving
+        if (modals.value) {
+        modals.value.agents.showDetails = false;
+        }
     }
 }
 </script>


### PR DESCRIPTION
## Description

This PR implements a two-stage warning system when editing existing agents in the DetailsModal.vue component. The goal is to prevent accidental global configuration changes without introducing "notification fatigue."

1. Visual Indicators: Individual input fields (group, sleep_min, sleep_max, watchdog, and contact) now dynamically apply the Bulma is-warning class (yellow border) if their value differs from the original state when the modal was opened.

2. Final Confirmation: Upon clicking "Save," if any changes are detected, a browser confirmation dialog appears stating: "Changes to agents affect all Caldera users! Are you sure you want to save these changes?"

## Related JIRA Ticket
VIRTS-4660

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Verified that changing an agent property triggers the yellow is-warning highlight.

- [x] Verified that clicking "Save" with changes triggers the window.confirm pop-up.

- [x] Verified that clicking "Cancel" on the pop-up prevents the API call.

- [x] Verified that after a successful save, the "dirty" state resets and highlights disappear.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
